### PR TITLE
Fix build failure with gcc-13

### DIFF
--- a/orbis-kernel/src/utils/Logs.cpp
+++ b/orbis-kernel/src/utils/Logs.cpp
@@ -4,6 +4,7 @@
 #include <string_view>
 #include <vector>
 #include <cstdarg>
+#include <cstdint>
 
 static void append_hex(std::string &out, std::uintmax_t value) {
   std::ostringstream buf;


### PR DESCRIPTION
Fixes the following errors:
`orbis-kernel/src/utils/Logs.cpp:8:42: error: 'std::uintmax_t' has not been declared`
`orbis-kernel/src/utils/Logs.cpp:17:41: error: 'uintptr_t' in namespace 'std' does not name a type`