### PR TITLE
Add cpplint & Styling Fixes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,15 @@
+name: Linting
+
+on:
+    push:
+    pull_request:
+
+jobs:
+    lint:
+        name: Lint
+        runs-on: ubuntu-latest
+        steps:
+        - uses: actions/checkout@v1
+        - uses: actions/setup-python@v1
+        - run: pip install cpplint
+        - run: cpplint --recursive .

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,0 +1,1 @@
+filter=-whitespace,-legal/copyright

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,1 +1,1 @@
-filter=-whitespace,-legal/copyright,-runtime/references
+filter=-whitespace,-legal/copyright,-runtime/references,-readability/todo,-build/c++11

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,1 +1,1 @@
-filter=-whitespace,-legal/copyright
+filter=-whitespace,-legal/copyright,-runtime/references

--- a/hw/amdgpu/shader/src/CfBuilder.cpp
+++ b/hw/amdgpu/shader/src/CfBuilder.cpp
@@ -1,8 +1,9 @@
-#include "CfBuilder.hpp"
-#include "Instruction.hpp"
 #include <cassert>
-#include <amdgpu/RemoteMemory.hpp>
 #include <unordered_set>
+
+#include "shader/CfBuilder.hpp"
+#include "shader/Instruction.hpp"
+#include <amdgpu/RemoteMemory.hpp>
 
 using namespace amdgpu;
 using namespace amdgpu::shader;
@@ -24,7 +25,7 @@ struct CfgBuilder {
       instHex += size;
 
       if (instruction.instClass == InstructionClass::Sop1) {
-        Sop1 sop1{instHex - size};
+        Sop1 sop1{ instHex - size };
 
         if (sop1.op == Sop1::Op::S_SETPC_B64 ||
             sop1.op == Sop1::Op::S_SWAPPC_B64) {
@@ -36,7 +37,7 @@ struct CfgBuilder {
       }
 
       if (instruction.instClass == InstructionClass::Sopp) {
-        Sopp sopp{instHex - size};
+        Sopp sopp{ instHex - size };
 
         if (sopp.op == Sopp::Op::S_ENDPGM) {
           bb->createReturn();
@@ -143,7 +144,7 @@ struct CfgBuilder {
         auto succ1Address = successors[1];
 
         branches.push_back(
-            {address + size - 4, 2, {successors[0], successors[1]}});
+          { address + size - 4, 2, {successors[0], successors[1]} });
 
         if (processed.insert(successors[0]).second) {
           workList.push_back(successors[0]);
@@ -152,7 +153,7 @@ struct CfgBuilder {
           workList.push_back(successors[1]);
         }
       } else if (successorsCount == 1) {
-        branches.push_back({address + size - 4, 1, {successors[0]}});
+        branches.push_back({ address + size - 4, 1, {successors[0]} });
 
         if (processed.insert(successors[0]).second) {
           workList.push_back(successors[0]);
@@ -165,8 +166,8 @@ struct CfgBuilder {
       assert(bb);
       if (branch.count == 2) {
         bb->createConditionalBranch(
-            context->getBasicBlockAt(branch.targets[0]),
-            context->getBasicBlockAt(branch.targets[1]));
+          context->getBasicBlockAt(branch.targets[0]),
+          context->getBasicBlockAt(branch.targets[1]));
       } else {
         bb->createBranch(context->getBasicBlockAt(branch.targets[0]));
       }
@@ -177,8 +178,8 @@ struct CfgBuilder {
 };
 
 cf::BasicBlock *amdgpu::shader::buildCf(cf::Context &ctxt,
-                                           RemoteMemory memory,
-                                           std::uint64_t entryPoint) {
+                                        RemoteMemory memory,
+                                        std::uint64_t entryPoint) {
   CfgBuilder builder;
   builder.context = &ctxt;
   builder.memory = memory;

--- a/hw/amdgpu/shader/src/Converter.cpp
+++ b/hw/amdgpu/shader/src/Converter.cpp
@@ -1,23 +1,24 @@
-#include "Converter.hpp"
-#include "CfBuilder.hpp"
-#include "ConverterContext.hpp"
-#include "Fragment.hpp"
-#include "FragmentTerminator.hpp"
-#include "Instruction.hpp"
-#include "RegisterId.hpp"
-#include "RegisterState.hpp"
-#include "cf.hpp"
-#include "amdgpu/RemoteMemory.hpp"
-#include "scf.hpp"
-#include "util/unreachable.hpp"
 #include <compare>
 #include <cstddef>
 #include <forward_list>
 #include <memory>
-#include <spirv/spirv.hpp>
 #include <unordered_map>
 #include <utility>
 #include <vector>
+
+#include "shader/Converter.hpp"
+#include "shader/CfBuilder.hpp"
+#include "shader/ConverterContext.hpp"
+#include "shader/Fragment.hpp"
+#include "shader/FragmentTerminator.hpp"
+#include "shader/Instruction.hpp"
+#include "shader/RegisterId.hpp"
+#include "shader/RegisterState.hpp"
+#include "shader/cf.hpp"
+#include "shader/scf.hpp"
+#include "amdgpu/RemoteMemory.hpp"
+#include "util/unreachable.hpp"
+#include <spirv/spirv.hpp>
 
 static void printInstructions(const scf::PrintOptions &options, unsigned depth,
                               std::uint32_t *instBegin, std::size_t size) {
@@ -100,16 +101,16 @@ private:
     auto inst = memory.getPointer<std::uint32_t>(fragment->registers->pc);
     auto instClass = getInstructionClass(*inst);
     return instClass == InstructionClass::Vop2 ||
-           instClass == InstructionClass::Vop3 ||
-           instClass == InstructionClass::Mubuf ||
-           instClass == InstructionClass::Mtbuf ||
-           instClass == InstructionClass::Mimg ||
-           instClass == InstructionClass::Ds ||
-           instClass == InstructionClass::Vintrp ||
-           instClass == InstructionClass::Exp ||
-           instClass == InstructionClass::Vop1 ||
-           instClass == InstructionClass::Vopc/* ||
-           instClass == InstructionClass::Smrd*/;
+      instClass == InstructionClass::Vop3 ||
+      instClass == InstructionClass::Mubuf ||
+      instClass == InstructionClass::Mtbuf ||
+      instClass == InstructionClass::Mimg ||
+      instClass == InstructionClass::Ds ||
+      instClass == InstructionClass::Vintrp ||
+      instClass == InstructionClass::Exp ||
+      instClass == InstructionClass::Vop1 ||
+      instClass == InstructionClass::Vopc/* ||
+      instClass == InstructionClass::Smrd*/;
   }
 
   spirv::BoolValue createExecTest(Fragment *fragment) {
@@ -118,9 +119,9 @@ private:
     auto boolT = context->getBoolType();
     auto uint32_0 = context->getUInt32(0);
     auto loIsNotZero =
-        builder.createINotEqual(boolT, fragment->getExecLo().value, uint32_0);
+      builder.createINotEqual(boolT, fragment->getExecLo().value, uint32_0);
     auto hiIsNotZero =
-        builder.createINotEqual(boolT, fragment->getExecHi().value, uint32_0);
+      builder.createINotEqual(boolT, fragment->getExecHi().value, uint32_0);
 
     return builder.createLogicalOr(boolT, loIsNotZero, hiIsNotZero);
   }
@@ -155,9 +156,9 @@ private:
           currentFragment->appendBranch(*bodyFragment);
           currentFragment->appendBranch(*mergeFragment);
           currentFragment->builder.createSelectionMerge(
-              mergeFragment->entryBlockId, {});
+            mergeFragment->entryBlockId, {});
           currentFragment->builder.createBranchConditional(
-              cond, bodyFragment->entryBlockId, mergeFragment->entryBlockId);
+            cond, bodyFragment->entryBlockId, mergeFragment->entryBlockId);
 
           initState(bodyFragment, bb->getAddress());
           bodyFragment->convert(bb->getSize());
@@ -185,10 +186,10 @@ private:
         currentFragment->appendBranch(*ifFalseFragment);
 
         currentFragment->builder.createSelectionMerge(
-            mergeFragment->entryBlockId, {});
+          mergeFragment->entryBlockId, {});
         currentFragment->builder.createBranchConditional(
-            currentFragment->branchCondition, ifTrueFragment->entryBlockId,
-            ifFalseFragment->entryBlockId);
+          currentFragment->branchCondition, ifTrueFragment->entryBlockId,
+          ifFalseFragment->entryBlockId);
 
         auto ifTrueLastBlock = convertBlock(ifElse->ifTrue, ifTrueFragment);
         auto ifFalseLastBlock = convertBlock(ifElse->ifFalse, ifFalseFragment);
@@ -238,12 +239,12 @@ private:
         auto block = buildCf(cfContext, memory, jumpAddress);
         auto basicBlockPrinter = [this](const scf::PrintOptions &opts,
                                         unsigned depth, scf::BasicBlock *bb) {
-          printInstructions(opts, depth,
-                            memory.getPointer<std::uint32_t>(bb->getAddress()),
-                            bb->getSize());
-        };
+                                          printInstructions(opts, depth,
+                                                            memory.getPointer<std::uint32_t>(bb->getAddress()),
+                                                            bb->getSize());
+          };
         auto scfBlock = scf::structurize(*scfContext, block);
-        scfBlock->print({.blockPrinter = basicBlockPrinter}, 0);
+        scfBlock->print({ .blockPrinter = basicBlockPrinter }, 0);
         std::fflush(stdout);
 
         auto targetFragment = function->createFragment();
@@ -262,7 +263,7 @@ private:
       if (dynCast<scf::Return>(node)) {
         currentFragment->appendBranch(function->exitFragment);
         currentFragment->builder.createBranch(
-            function->exitFragment.entryBlockId);
+          function->exitFragment.entryBlockId);
         return nullptr;
       }
 
@@ -275,9 +276,9 @@ private:
 }; // namespace amdgpu::shader
 
 amdgpu::shader::Shader amdgpu::shader::convert(
-    RemoteMemory memory, Stage stage, std::uint64_t entry,
-    std::span<const std::uint32_t> userSpgrs, int bindingOffset,
-    std::uint32_t dimX, std::uint32_t dimY, std::uint32_t dimZ) {
+  RemoteMemory memory, Stage stage, std::uint64_t entry,
+  std::span<const std::uint32_t> userSpgrs, int bindingOffset,
+  std::uint32_t dimX, std::uint32_t dimY, std::uint32_t dimZ) {
   ConverterContext ctxt(memory, stage);
   auto &builder = ctxt.getBuilder();
   builder.createCapability(spv::Capability::Shader);
@@ -334,9 +335,9 @@ amdgpu::shader::Shader amdgpu::shader::convert(
     std::uint32_t descriptorSet = 0;
 
     ctxt.getBuilder().createDecorate(
-        uniform.variable, spv::Decoration::DescriptorSet, {{descriptorSet}});
+      uniform.variable, spv::Decoration::DescriptorSet, { {descriptorSet} });
     ctxt.getBuilder().createDecorate(uniform.variable, spv::Decoration::Binding,
-                                     {{newUniform.binding}});
+                                     { {newUniform.binding} });
 
     switch (uniform.typeId) {
     case TypeId::Sampler:
@@ -381,7 +382,7 @@ amdgpu::shader::Shader amdgpu::shader::convert(
                              ctxt.getInterfaces());
     builder.createExecutionMode(mainFunction->builder.id,
                                 spv::ExecutionMode::LocalSize,
-                                {{dimX, dimY, dimZ}});
+                                { {dimX, dimY, dimZ} });
   }
 
   result.spirv = ctxt.getBuilder().build(SPV_VERSION, 0);

--- a/hw/amdgpu/shader/src/ConverterContext.cpp
+++ b/hw/amdgpu/shader/src/ConverterContext.cpp
@@ -1,4 +1,4 @@
-#include "ConverterContext.hpp"
+#include "shader/ConverterContext.hpp"
 #include "util/unreachable.hpp"
 using namespace amdgpu::shader;
 

--- a/hw/amdgpu/shader/src/Fragment.cpp
+++ b/hw/amdgpu/shader/src/Fragment.cpp
@@ -1,13 +1,13 @@
-#include "Fragment.hpp"
-#include "ConverterContext.hpp"
-#include "RegisterId.hpp"
-#include "RegisterState.hpp"
+#include <bit>
 
 #include <spirv/GLSL.std.450.h>
+
+#include "shader/Fragment.hpp"
+#include "shader/ConverterContext.hpp"
+#include "shader/RegisterId.hpp"
+#include "shader/RegisterState.hpp"
 #include <spirv/spirv-instruction.hpp>
 #include <util/unreachable.hpp>
-
-#include <bit>
 
 using namespace amdgpu::shader;
 
@@ -154,11 +154,11 @@ spirv::Type convertFromFormat(spirv::Value *result, int count,
   auto loadType = pickBufferType(surfaceFormat, channelType);
 
   auto uniform =
-      fragment.context->getOrCreateStorageBuffer(vBufferData, loadType);
+    fragment.context->getOrCreateStorageBuffer(vBufferData, loadType);
   uniform->accessOp |= AccessOp::Load;
 
   auto storageBufferPointerType = fragment.context->getPointerType(
-      spv::StorageClass::StorageBuffer, loadType);
+    spv::StorageClass::StorageBuffer, loadType);
 
   auto &builder = fragment.builder;
 
@@ -190,16 +190,16 @@ spirv::Type convertFromFormat(spirv::Value *result, int count,
 
       if (channel != 0) {
         channelOffset =
-            builder.createIAdd(fragment.context->getUInt32Type(), channelOffset,
-                               fragment.context->getUInt32(channel));
+          builder.createIAdd(fragment.context->getUInt32Type(), channelOffset,
+                             fragment.context->getUInt32(channel));
       }
 
       auto uniformPointerValue = fragment.builder.createAccessChain(
-          storageBufferPointerType, uniform->variable,
-          {{fragment.context->getUInt32(0), channelOffset}});
+        storageBufferPointerType, uniform->variable,
+        { {fragment.context->getUInt32(0), channelOffset} });
 
       auto channelValue = fragment.builder.createLoad(
-          fragment.context->getType(loadType), uniformPointerValue);
+        fragment.context->getType(loadType), uniformPointerValue);
       switch (channelType) {
       case kTextureChannelTypeFloat:
       case kTextureChannelTypeSInt:
@@ -209,20 +209,20 @@ spirv::Type convertFromFormat(spirv::Value *result, int count,
 
       case kTextureChannelTypeUNorm: {
         auto maxValue =
-            (static_cast<std::uint64_t>(1) << (channelSize * 8)) - 1;
+          (static_cast<std::uint64_t>(1) << (channelSize * 8)) - 1;
 
         auto uintChannelValue = spirv::cast<spirv::UIntValue>(channelValue);
 
         if (loadType != TypeId::UInt32) {
           uintChannelValue = builder.createUConvert(
-              fragment.context->getUInt32Type(), uintChannelValue);
+            fragment.context->getUInt32Type(), uintChannelValue);
         }
 
         auto floatChannelValue = builder.createConvertUToF(
-            fragment.context->getFloat32Type(), uintChannelValue);
+          fragment.context->getFloat32Type(), uintChannelValue);
         floatChannelValue = builder.createFDiv(
-            fragment.context->getFloat32Type(), floatChannelValue,
-            fragment.context->getFloat32(maxValue));
+          fragment.context->getFloat32Type(), floatChannelValue,
+          fragment.context->getFloat32(maxValue));
         result[channel] = floatChannelValue;
         resultType = fragment.context->getFloat32Type();
         break;
@@ -230,29 +230,29 @@ spirv::Type convertFromFormat(spirv::Value *result, int count,
 
       case kTextureChannelTypeSNorm: {
         auto maxValue =
-            (static_cast<std::uint64_t>(1) << (channelSize * 8 - 1)) - 1;
+          (static_cast<std::uint64_t>(1) << (channelSize * 8 - 1)) - 1;
 
         auto uintChannelValue = spirv::cast<spirv::SIntValue>(channelValue);
 
         if (loadType != TypeId::SInt32) {
           uintChannelValue = builder.createSConvert(
-              fragment.context->getSint32Type(), uintChannelValue);
+            fragment.context->getSint32Type(), uintChannelValue);
         }
 
         auto floatChannelValue = builder.createConvertSToF(
-            fragment.context->getFloat32Type(), uintChannelValue);
+          fragment.context->getFloat32Type(), uintChannelValue);
 
         floatChannelValue = builder.createFDiv(
-            fragment.context->getFloat32Type(), floatChannelValue,
-            fragment.context->getFloat32(maxValue));
+          fragment.context->getFloat32Type(), floatChannelValue,
+          fragment.context->getFloat32(maxValue));
 
         auto glslStd450 = fragment.context->getGlslStd450();
         floatChannelValue =
-            spirv::cast<spirv::FloatValue>(fragment.builder.createExtInst(
-                fragment.context->getFloat32Type(), glslStd450,
-                GLSLstd450FClamp,
-                {{floatChannelValue, fragment.context->getFloat32(-1),
-                  fragment.context->getFloat32(1)}}));
+          spirv::cast<spirv::FloatValue>(fragment.builder.createExtInst(
+            fragment.context->getFloat32Type(), glslStd450,
+            GLSLstd450FClamp,
+            { {floatChannelValue, fragment.context->getFloat32(-1),
+              fragment.context->getFloat32(1)} }));
         result[channel] = floatChannelValue;
         resultType = fragment.context->getFloat32Type();
         break;
@@ -263,11 +263,11 @@ spirv::Type convertFromFormat(spirv::Value *result, int count,
 
         if (loadType != TypeId::UInt32) {
           uintChannelValue = builder.createUConvert(
-              fragment.context->getUInt32Type(), uintChannelValue);
+            fragment.context->getUInt32Type(), uintChannelValue);
         }
 
         auto floatChannelValue = builder.createConvertUToF(
-            fragment.context->getFloat32Type(), uintChannelValue);
+          fragment.context->getFloat32Type(), uintChannelValue);
 
         result[channel] = floatChannelValue;
         resultType = fragment.context->getFloat32Type();
@@ -279,11 +279,11 @@ spirv::Type convertFromFormat(spirv::Value *result, int count,
 
         if (loadType != TypeId::SInt32) {
           uintChannelValue = builder.createSConvert(
-              fragment.context->getSint32Type(), uintChannelValue);
+            fragment.context->getSint32Type(), uintChannelValue);
         }
 
         auto floatChannelValue = builder.createConvertSToF(
-            fragment.context->getFloat32Type(), uintChannelValue);
+          fragment.context->getFloat32Type(), uintChannelValue);
 
         result[channel] = floatChannelValue;
         resultType = fragment.context->getFloat32Type();
@@ -292,28 +292,28 @@ spirv::Type convertFromFormat(spirv::Value *result, int count,
 
       case kTextureChannelTypeSNormNoZero: {
         auto maxValue =
-            (static_cast<std::uint64_t>(1) << (channelSize * 8)) - 1;
+          (static_cast<std::uint64_t>(1) << (channelSize * 8)) - 1;
 
         auto uintChannelValue = spirv::cast<spirv::SIntValue>(channelValue);
 
         if (loadType != TypeId::SInt32) {
           uintChannelValue = builder.createSConvert(
-              fragment.context->getSint32Type(), uintChannelValue);
+            fragment.context->getSint32Type(), uintChannelValue);
         }
 
         auto floatChannelValue = builder.createConvertSToF(
-            fragment.context->getFloat32Type(), uintChannelValue);
+          fragment.context->getFloat32Type(), uintChannelValue);
 
         floatChannelValue = builder.createFMul(
-            fragment.context->getFloat32Type(), floatChannelValue,
-            fragment.context->getFloat32(2));
+          fragment.context->getFloat32Type(), floatChannelValue,
+          fragment.context->getFloat32(2));
         floatChannelValue = builder.createFAdd(
-            fragment.context->getFloat32Type(), floatChannelValue,
-            fragment.context->getFloat32(1));
+          fragment.context->getFloat32Type(), floatChannelValue,
+          fragment.context->getFloat32(1));
 
         floatChannelValue = builder.createFDiv(
-            fragment.context->getFloat32Type(), floatChannelValue,
-            fragment.context->getFloat32(maxValue));
+          fragment.context->getFloat32Type(), floatChannelValue,
+          fragment.context->getFloat32(maxValue));
 
         result[channel] = floatChannelValue;
         resultType = fragment.context->getFloat32Type();
@@ -327,8 +327,8 @@ spirv::Type convertFromFormat(spirv::Value *result, int count,
 
     for (; channel < count; ++channel) {
       result[channel] =
-          fragment.createBitcast(resultType, fragment.context->getUInt32Type(),
-                                 fragment.context->getUInt32(0));
+        fragment.createBitcast(resultType, fragment.context->getUInt32Type(),
+                               fragment.context->getUInt32(0));
     }
     return resultType;
   }
@@ -349,11 +349,11 @@ void convertToFormat(RegisterId sourceRegister, int count, Fragment &fragment,
   auto storeType = pickBufferType(surfaceFormat, channelType);
 
   auto uniform =
-      fragment.context->getOrCreateStorageBuffer(vBufferData, storeType);
+    fragment.context->getOrCreateStorageBuffer(vBufferData, storeType);
   uniform->accessOp |= AccessOp::Store;
 
   auto uniformPointerType = fragment.context->getPointerType(
-      spv::StorageClass::StorageBuffer, storeType);
+    spv::StorageClass::StorageBuffer, storeType);
 
   auto &builder = fragment.builder;
   switch (surfaceFormat) {
@@ -384,24 +384,24 @@ void convertToFormat(RegisterId sourceRegister, int count, Fragment &fragment,
 
       if (channel != 0) {
         channelOffset =
-            builder.createIAdd(fragment.context->getUInt32Type(), channelOffset,
-                               fragment.context->getUInt32(channel));
+          builder.createIAdd(fragment.context->getUInt32Type(), channelOffset,
+                             fragment.context->getUInt32(channel));
       }
 
       auto uniformPointerValue = fragment.builder.createAccessChain(
-          uniformPointerType, uniform->variable,
-          {{fragment.context->getUInt32(0), channelOffset}});
+        uniformPointerType, uniform->variable,
+        { {fragment.context->getUInt32(0), channelOffset} });
 
       switch (channelType) {
       case kTextureChannelTypeFloat:
       case kTextureChannelTypeSInt:
       case kTextureChannelTypeUInt:
         fragment.builder.createStore(
-            uniformPointerValue,
-            fragment
-                .getOperand(RegisterId::Raw(sourceRegister + channel),
-                            storeType)
-                .value);
+          uniformPointerValue,
+          fragment
+          .getOperand(RegisterId::Raw(sourceRegister + channel),
+                      storeType)
+          .value);
         break;
 
       default:
@@ -411,17 +411,17 @@ void convertToFormat(RegisterId sourceRegister, int count, Fragment &fragment,
 
     for (; channel < count; ++channel) {
       auto channelOffset =
-          builder.createIAdd(fragment.context->getUInt32Type(), offset,
-                             fragment.context->getUInt32(channel));
+        builder.createIAdd(fragment.context->getUInt32Type(), offset,
+                           fragment.context->getUInt32(channel));
       auto uniformPointerValue = fragment.builder.createAccessChain(
-          uniformPointerType, uniform->variable,
-          {{fragment.context->getUInt32(0), channelOffset}});
+        uniformPointerType, uniform->variable,
+        { {fragment.context->getUInt32(0), channelOffset} });
 
       fragment.builder.createStore(
-          uniformPointerValue,
-          fragment.createBitcast(fragment.context->getType(storeType),
-                                 fragment.context->getUInt32Type(),
-                                 fragment.context->getUInt32(0)));
+        uniformPointerValue,
+        fragment.createBitcast(fragment.context->getType(storeType),
+                               fragment.context->getUInt32Type(),
+                               fragment.context->getUInt32(0)));
     }
 
     return;
@@ -529,7 +529,7 @@ struct GnmTBuffer {
 
   std::uint64_t getAddress() const {
     return static_cast<std::uint64_t>(static_cast<std::uint32_t>(baseaddr256))
-           << 8;
+      << 8;
   }
 };
 
@@ -618,13 +618,13 @@ Value doCmpOp(Fragment &fragment, TypeId type, spirv::Value src0,
     break;
   case CmpKind::O:
     cmp = fragment.builder.createLogicalAnd(
-        boolT, fragment.builder.createFOrdEqual(boolT, src0, src0),
-        fragment.builder.createFOrdEqual(boolT, src1, src1));
+      boolT, fragment.builder.createFOrdEqual(boolT, src0, src0),
+      fragment.builder.createFOrdEqual(boolT, src1, src1));
     break;
   case CmpKind::U:
     cmp = fragment.builder.createLogicalAnd(
-        boolT, fragment.builder.createFUnordNotEqual(boolT, src0, src0),
-        fragment.builder.createFUnordNotEqual(boolT, src1, src1));
+      boolT, fragment.builder.createFUnordNotEqual(boolT, src0, src0),
+      fragment.builder.createFUnordNotEqual(boolT, src1, src1));
     break;
   case CmpKind::NGE:
     cmp = fragment.builder.createFUnordLessThan(boolT, src0, src1);
@@ -661,15 +661,15 @@ Value doCmpOp(Fragment &fragment, TypeId type, spirv::Value src0,
   auto uint32T = fragment.context->getUInt32Type();
   auto uint32_0 = fragment.context->getUInt32(0);
   auto result = fragment.builder.createSelect(
-      uint32T, cmp, fragment.context->getUInt32(1), uint32_0);
+    uint32T, cmp, fragment.context->getUInt32(1), uint32_0);
 
   if ((flags & CmpFlags::X) == CmpFlags::X) {
-    fragment.setOperand(RegisterId::ExecLo, {uint32T, result});
-    fragment.setOperand(RegisterId::ExecHi, {uint32T, uint32_0});
+    fragment.setOperand(RegisterId::ExecLo, { uint32T, result });
+    fragment.setOperand(RegisterId::ExecHi, { uint32T, uint32_0 });
   }
 
   // TODO: handle flags
-  return {uint32T, result};
+  return { uint32T, result };
 };
 
 void convertVop2(Fragment &fragment, Vop2 inst) {
@@ -684,11 +684,11 @@ void convertVop2(Fragment &fragment, Vop2 inst) {
     auto src1 = fragment.getVectorOperand(inst.vsrc1, TypeId::Float32).value;
 
     auto src = fragment.builder.createCompositeConstruct(
-        float2T, std::array{src0, src1});
+      float2T, std::array{ src0, src1 });
     auto dst = fragment.builder.createExtInst(
-        uintT, glslStd450, GLSLstd450PackHalf2x16, std::array{src});
+      uintT, glslStd450, GLSLstd450PackHalf2x16, std::array{ src });
 
-    fragment.setVectorOperand(inst.vdst, {uintT, dst});
+    fragment.setVectorOperand(inst.vdst, { uintT, dst });
     break;
   }
   case Vop2::Op::V_AND_B32: {
@@ -697,8 +697,8 @@ void convertVop2(Fragment &fragment, Vop2 inst) {
     auto uintT = fragment.context->getType(TypeId::UInt32);
 
     fragment.setVectorOperand(
-        inst.vdst,
-        {uintT, fragment.builder.createBitwiseAnd(uintT, src0, src1)});
+      inst.vdst,
+      { uintT, fragment.builder.createBitwiseAnd(uintT, src0, src1) });
     break;
   }
 
@@ -708,8 +708,8 @@ void convertVop2(Fragment &fragment, Vop2 inst) {
     auto uintT = fragment.context->getType(TypeId::UInt32);
 
     fragment.setVectorOperand(
-        inst.vdst,
-        {uintT, fragment.builder.createBitwiseOr(uintT, src0, src1)});
+      inst.vdst,
+      { uintT, fragment.builder.createBitwiseOr(uintT, src0, src1) });
     break;
   }
 
@@ -718,15 +718,15 @@ void convertVop2(Fragment &fragment, Vop2 inst) {
     auto src1 = fragment.getVectorOperand(inst.vsrc1, TypeId::UInt32).value;
     auto uintT = fragment.context->getType(TypeId::UInt32);
     auto resultStruct =
-        fragment.context->getStructType(std::array{uintT, uintT});
+      fragment.context->getStructType(std::array{ uintT, uintT });
     auto result = fragment.builder.createIAddCarry(resultStruct, src0, src1);
     fragment.setVectorOperand(
-        inst.vdst,
-        {uintT, fragment.builder.createCompositeExtract(
-                    uintT, result, std::array{static_cast<std::uint32_t>(0)})});
+      inst.vdst,
+      { uintT, fragment.builder.createCompositeExtract(
+                  uintT, result, std::array{static_cast<std::uint32_t>(0)}) });
     fragment.setVcc(
-        {uintT, fragment.builder.createCompositeExtract(
-                    uintT, result, std::array{static_cast<std::uint32_t>(1)})});
+      { uintT, fragment.builder.createCompositeExtract(
+                  uintT, result, std::array{static_cast<std::uint32_t>(1)}) });
     // TODO: update vcc hi
     break;
   }
@@ -736,42 +736,42 @@ void convertVop2(Fragment &fragment, Vop2 inst) {
     auto src1 = fragment.getVectorOperand(inst.vsrc1, TypeId::UInt32).value;
     auto uintT = fragment.context->getType(TypeId::UInt32);
     auto resultStruct =
-        fragment.context->getStructType(std::array{uintT, uintT});
+      fragment.context->getStructType(std::array{ uintT, uintT });
     auto result = fragment.builder.createISubBorrow(resultStruct, src0, src1);
     fragment.setVectorOperand(
-        inst.vdst,
-        {uintT, fragment.builder.createCompositeExtract(
-                    uintT, result, std::array{static_cast<std::uint32_t>(0)})});
+      inst.vdst,
+      { uintT, fragment.builder.createCompositeExtract(
+                  uintT, result, std::array{static_cast<std::uint32_t>(0)}) });
     fragment.setVcc(
-        {uintT, fragment.builder.createCompositeExtract(
-                    uintT, result, std::array{static_cast<std::uint32_t>(1)})});
+      { uintT, fragment.builder.createCompositeExtract(
+                  uintT, result, std::array{static_cast<std::uint32_t>(1)}) });
     // TODO: update vcc hi
     break;
   }
 
   case Vop2::Op::V_MAC_F32: {
     auto src0 = spirv::cast<spirv::FloatValue>(
-        fragment.getScalarOperand(inst.src0, TypeId::Float32).value);
+      fragment.getScalarOperand(inst.src0, TypeId::Float32).value);
     auto src1 = spirv::cast<spirv::FloatValue>(
-        fragment.getVectorOperand(inst.vsrc1, TypeId::Float32).value);
+      fragment.getVectorOperand(inst.vsrc1, TypeId::Float32).value);
     auto dst = spirv::cast<spirv::FloatValue>(
-        fragment.getVectorOperand(inst.vdst, TypeId::Float32).value);
+      fragment.getVectorOperand(inst.vdst, TypeId::Float32).value);
     auto floatT = fragment.context->getFloat32Type();
 
     auto result = fragment.builder.createFAdd(
-        floatT, fragment.builder.createFMul(floatT, src0, src1), dst);
+      floatT, fragment.builder.createFMul(floatT, src0, src1), dst);
 
-    fragment.setVectorOperand(inst.vdst, {floatT, result});
+    fragment.setVectorOperand(inst.vdst, { floatT, result });
     break;
   }
 
   case Vop2::Op::V_MAC_LEGACY_F32: {
     auto src0 = spirv::cast<spirv::FloatValue>(
-        fragment.getScalarOperand(inst.src0, TypeId::Float32).value);
+      fragment.getScalarOperand(inst.src0, TypeId::Float32).value);
     auto src1 = spirv::cast<spirv::FloatValue>(
-        fragment.getVectorOperand(inst.vsrc1, TypeId::Float32).value);
+      fragment.getVectorOperand(inst.vsrc1, TypeId::Float32).value);
     auto dst = spirv::cast<spirv::FloatValue>(
-        fragment.getVectorOperand(inst.vdst, TypeId::Float32).value);
+      fragment.getVectorOperand(inst.vdst, TypeId::Float32).value);
     auto floatT = fragment.context->getFloat32Type();
     auto boolT = fragment.context->getBoolType();
     auto float0 = fragment.context->getFloat32(0);
@@ -779,119 +779,119 @@ void convertVop2(Fragment &fragment, Vop2 inst) {
     auto src0IsZero = fragment.builder.createFOrdEqual(boolT, src0, float0);
     auto src1IsZero = fragment.builder.createFOrdEqual(boolT, src1, float0);
     auto anySrcIsZero =
-        fragment.builder.createLogicalOr(boolT, src0IsZero, src1IsZero);
+      fragment.builder.createLogicalOr(boolT, src0IsZero, src1IsZero);
 
     auto result = fragment.builder.createFAdd(
-        floatT,
-        fragment.builder.createSelect(
-            floatT, anySrcIsZero, float0,
-            fragment.builder.createFMul(floatT, src0, src1)),
-        dst);
+      floatT,
+      fragment.builder.createSelect(
+        floatT, anySrcIsZero, float0,
+        fragment.builder.createFMul(floatT, src0, src1)),
+      dst);
 
-    fragment.setVectorOperand(inst.vdst, {floatT, result});
+    fragment.setVectorOperand(inst.vdst, { floatT, result });
     break;
   }
 
   case Vop2::Op::V_MUL_F32: {
     auto src0 = spirv::cast<spirv::FloatValue>(
-        fragment.getScalarOperand(inst.src0, TypeId::Float32).value);
+      fragment.getScalarOperand(inst.src0, TypeId::Float32).value);
     auto src1 = spirv::cast<spirv::FloatValue>(
-        fragment.getVectorOperand(inst.vsrc1, TypeId::Float32).value);
+      fragment.getVectorOperand(inst.vsrc1, TypeId::Float32).value);
     auto floatT = fragment.context->getFloat32Type();
 
     auto result = fragment.builder.createFMul(floatT, src0, src1);
 
-    fragment.setVectorOperand(inst.vdst, {floatT, result});
+    fragment.setVectorOperand(inst.vdst, { floatT, result });
     break;
   }
 
   case Vop2::Op::V_ADD_F32: {
     auto src0 = spirv::cast<spirv::FloatValue>(
-        fragment.getScalarOperand(inst.src0, TypeId::Float32).value);
+      fragment.getScalarOperand(inst.src0, TypeId::Float32).value);
     auto src1 = spirv::cast<spirv::FloatValue>(
-        fragment.getVectorOperand(inst.vsrc1, TypeId::Float32).value);
+      fragment.getVectorOperand(inst.vsrc1, TypeId::Float32).value);
     auto floatT = fragment.context->getFloat32Type();
 
     auto result = fragment.builder.createFAdd(floatT, src0, src1);
 
-    fragment.setVectorOperand(inst.vdst, {floatT, result});
+    fragment.setVectorOperand(inst.vdst, { floatT, result });
     break;
   }
 
   case Vop2::Op::V_SUB_F32: {
     auto src0 = spirv::cast<spirv::FloatValue>(
-        fragment.getScalarOperand(inst.src0, TypeId::Float32).value);
+      fragment.getScalarOperand(inst.src0, TypeId::Float32).value);
     auto src1 = spirv::cast<spirv::FloatValue>(
-        fragment.getVectorOperand(inst.vsrc1, TypeId::Float32).value);
+      fragment.getVectorOperand(inst.vsrc1, TypeId::Float32).value);
     auto floatT = fragment.context->getFloat32Type();
 
     auto result = fragment.builder.createFSub(floatT, src0, src1);
 
-    fragment.setVectorOperand(inst.vdst, {floatT, result});
+    fragment.setVectorOperand(inst.vdst, { floatT, result });
     break;
   }
   case Vop2::Op::V_SUBREV_F32: {
     auto src0 = spirv::cast<spirv::FloatValue>(
-        fragment.getScalarOperand(inst.src0, TypeId::Float32).value);
+      fragment.getScalarOperand(inst.src0, TypeId::Float32).value);
     auto src1 = spirv::cast<spirv::FloatValue>(
-        fragment.getVectorOperand(inst.vsrc1, TypeId::Float32).value);
+      fragment.getVectorOperand(inst.vsrc1, TypeId::Float32).value);
     auto floatT = fragment.context->getFloat32Type();
 
     auto result = fragment.builder.createFSub(floatT, src1, src0);
 
-    fragment.setVectorOperand(inst.vdst, {floatT, result});
+    fragment.setVectorOperand(inst.vdst, { floatT, result });
     break;
   }
   case Vop2::Op::V_SUBREV_I32: {
     auto src0 = spirv::cast<spirv::SIntValue>(
-        fragment.getScalarOperand(inst.src0, TypeId::SInt32).value);
+      fragment.getScalarOperand(inst.src0, TypeId::SInt32).value);
     auto src1 = spirv::cast<spirv::SIntValue>(
-        fragment.getVectorOperand(inst.vsrc1, TypeId::SInt32).value);
+      fragment.getVectorOperand(inst.vsrc1, TypeId::SInt32).value);
     auto floatT = fragment.context->getSint32Type();
 
     auto result = fragment.builder.createISub(floatT, src1, src0);
 
-    fragment.setVectorOperand(inst.vdst, {floatT, result});
+    fragment.setVectorOperand(inst.vdst, { floatT, result });
     break;
   }
 
   case Vop2::Op::V_MIN_F32: {
     auto src0 = spirv::cast<spirv::FloatValue>(
-        fragment.getScalarOperand(inst.src0, TypeId::Float32).value);
+      fragment.getScalarOperand(inst.src0, TypeId::Float32).value);
     auto src1 = spirv::cast<spirv::FloatValue>(
-        fragment.getVectorOperand(inst.vsrc1, TypeId::Float32).value);
+      fragment.getVectorOperand(inst.vsrc1, TypeId::Float32).value);
     auto floatT = fragment.context->getFloat32Type();
     auto boolT = fragment.context->getBoolType();
 
     auto result = fragment.builder.createSelect(
-        floatT, fragment.builder.createFOrdLessThan(boolT, src0, src1), src0,
-        src1);
+      floatT, fragment.builder.createFOrdLessThan(boolT, src0, src1), src0,
+      src1);
 
-    fragment.setVectorOperand(inst.vdst, {floatT, result});
+    fragment.setVectorOperand(inst.vdst, { floatT, result });
     break;
   }
 
   case Vop2::Op::V_MAX_F32: {
     auto src0 = spirv::cast<spirv::FloatValue>(
-        fragment.getScalarOperand(inst.src0, TypeId::Float32).value);
+      fragment.getScalarOperand(inst.src0, TypeId::Float32).value);
     auto src1 = spirv::cast<spirv::FloatValue>(
-        fragment.getVectorOperand(inst.vsrc1, TypeId::Float32).value);
+      fragment.getVectorOperand(inst.vsrc1, TypeId::Float32).value);
     auto floatT = fragment.context->getFloat32Type();
     auto boolT = fragment.context->getBoolType();
 
     auto result = fragment.builder.createSelect(
-        floatT, fragment.builder.createFOrdGreaterThanEqual(boolT, src0, src1),
-        src0, src1);
+      floatT, fragment.builder.createFOrdGreaterThanEqual(boolT, src0, src1),
+      src0, src1);
 
-    fragment.setVectorOperand(inst.vdst, {floatT, result});
+    fragment.setVectorOperand(inst.vdst, { floatT, result });
     break;
   }
 
   case Vop2::Op::V_MUL_LEGACY_F32: {
     auto src0 = spirv::cast<spirv::FloatValue>(
-        fragment.getScalarOperand(inst.src0, TypeId::Float32).value);
+      fragment.getScalarOperand(inst.src0, TypeId::Float32).value);
     auto src1 = spirv::cast<spirv::FloatValue>(
-        fragment.getVectorOperand(inst.vsrc1, TypeId::Float32).value);
+      fragment.getVectorOperand(inst.vsrc1, TypeId::Float32).value);
     auto floatT = fragment.context->getFloat32Type();
     auto boolT = fragment.context->getBoolType();
     auto float0 = fragment.context->getFloat32(0);
@@ -899,123 +899,123 @@ void convertVop2(Fragment &fragment, Vop2 inst) {
     auto src0IsZero = fragment.builder.createFOrdEqual(boolT, src0, float0);
     auto src1IsZero = fragment.builder.createFOrdEqual(boolT, src1, float0);
     auto anySrcIsZero =
-        fragment.builder.createLogicalOr(boolT, src0IsZero, src1IsZero);
+      fragment.builder.createLogicalOr(boolT, src0IsZero, src1IsZero);
 
     auto result = fragment.builder.createSelect(
-        floatT, anySrcIsZero, float0,
-        fragment.builder.createFMul(floatT, src0, src1));
+      floatT, anySrcIsZero, float0,
+      fragment.builder.createFMul(floatT, src0, src1));
 
-    fragment.setVectorOperand(inst.vdst, {floatT, result});
+    fragment.setVectorOperand(inst.vdst, { floatT, result });
     break;
   }
 
   case Vop2::Op::V_MADAK_F32: {
     auto src0 = spirv::cast<spirv::FloatValue>(
-        fragment.getScalarOperand(inst.src0, TypeId::Float32).value);
+      fragment.getScalarOperand(inst.src0, TypeId::Float32).value);
     auto src1 = spirv::cast<spirv::FloatValue>(
-        fragment.getVectorOperand(inst.vsrc1, TypeId::Float32).value);
+      fragment.getVectorOperand(inst.vsrc1, TypeId::Float32).value);
     auto constant = spirv::cast<spirv::FloatValue>(
-        fragment.getScalarOperand(255, TypeId::Float32).value);
+      fragment.getScalarOperand(255, TypeId::Float32).value);
     auto floatT = fragment.context->getFloat32Type();
 
     auto result = fragment.builder.createFAdd(
-        floatT, fragment.builder.createFMul(floatT, src0, src1), constant);
+      floatT, fragment.builder.createFMul(floatT, src0, src1), constant);
 
-    fragment.setVectorOperand(inst.vdst, {floatT, result});
+    fragment.setVectorOperand(inst.vdst, { floatT, result });
     break;
   }
 
   case Vop2::Op::V_MADMK_F32: {
     auto src0 = spirv::cast<spirv::FloatValue>(
-        fragment.getScalarOperand(inst.src0, TypeId::Float32).value);
+      fragment.getScalarOperand(inst.src0, TypeId::Float32).value);
     auto src1 = spirv::cast<spirv::FloatValue>(
-        fragment.getVectorOperand(inst.vsrc1, TypeId::Float32).value);
+      fragment.getVectorOperand(inst.vsrc1, TypeId::Float32).value);
     auto constant = spirv::cast<spirv::FloatValue>(
-        fragment.getScalarOperand(255, TypeId::Float32).value);
+      fragment.getScalarOperand(255, TypeId::Float32).value);
     auto floatT = fragment.context->getFloat32Type();
 
     auto result = fragment.builder.createFAdd(
-        floatT, fragment.builder.createFMul(floatT, src0, constant), src1);
+      floatT, fragment.builder.createFMul(floatT, src0, constant), src1);
 
-    fragment.setVectorOperand(inst.vdst, {floatT, result});
+    fragment.setVectorOperand(inst.vdst, { floatT, result });
     break;
   }
 
   case Vop2::Op::V_LSHL_B32: {
     auto src0 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.src0, TypeId::UInt32).value);
+      fragment.getScalarOperand(inst.src0, TypeId::UInt32).value);
     auto src1 = spirv::cast<spirv::UIntValue>(
-        fragment.getVectorOperand(inst.vsrc1, TypeId::UInt32).value);
+      fragment.getVectorOperand(inst.vsrc1, TypeId::UInt32).value);
     auto uintT = fragment.context->getType(TypeId::UInt32);
 
     fragment.setVectorOperand(
-        inst.vdst,
-        {uintT, fragment.builder.createShiftLeftLogical(uintT, src0, src1)});
+      inst.vdst,
+      { uintT, fragment.builder.createShiftLeftLogical(uintT, src0, src1) });
     break;
   }
 
   case Vop2::Op::V_LSHLREV_B32: {
     auto src0 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.src0, TypeId::UInt32).value);
+      fragment.getScalarOperand(inst.src0, TypeId::UInt32).value);
     auto src1 = spirv::cast<spirv::UIntValue>(
-        fragment.getVectorOperand(inst.vsrc1, TypeId::UInt32).value);
+      fragment.getVectorOperand(inst.vsrc1, TypeId::UInt32).value);
     auto uintT = fragment.context->getType(TypeId::UInt32);
 
     fragment.setVectorOperand(
-        inst.vdst,
-        {uintT, fragment.builder.createShiftLeftLogical(uintT, src1, src0)});
+      inst.vdst,
+      { uintT, fragment.builder.createShiftLeftLogical(uintT, src1, src0) });
     break;
   }
 
   case Vop2::Op::V_LSHR_B32: {
     auto src0 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.src0, TypeId::UInt32).value);
+      fragment.getScalarOperand(inst.src0, TypeId::UInt32).value);
     auto src1 = spirv::cast<spirv::UIntValue>(
-        fragment.getVectorOperand(inst.vsrc1, TypeId::UInt32).value);
+      fragment.getVectorOperand(inst.vsrc1, TypeId::UInt32).value);
     auto uintT = fragment.context->getType(TypeId::UInt32);
 
     fragment.setVectorOperand(
-        inst.vdst,
-        {uintT, fragment.builder.createShiftRightLogical(uintT, src0, src1)});
+      inst.vdst,
+      { uintT, fragment.builder.createShiftRightLogical(uintT, src0, src1) });
     break;
   }
 
   case Vop2::Op::V_LSHRREV_B32: {
     auto src0 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.src0, TypeId::UInt32).value);
+      fragment.getScalarOperand(inst.src0, TypeId::UInt32).value);
     auto src1 = spirv::cast<spirv::UIntValue>(
-        fragment.getVectorOperand(inst.vsrc1, TypeId::UInt32).value);
+      fragment.getVectorOperand(inst.vsrc1, TypeId::UInt32).value);
     auto uintT = fragment.context->getType(TypeId::UInt32);
 
     fragment.setVectorOperand(
-        inst.vdst,
-        {uintT, fragment.builder.createShiftRightLogical(uintT, src1, src0)});
+      inst.vdst,
+      { uintT, fragment.builder.createShiftRightLogical(uintT, src1, src0) });
     break;
   }
 
   case Vop2::Op::V_ASHR_I32: {
     auto src0 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.src0, TypeId::SInt32).value);
+      fragment.getScalarOperand(inst.src0, TypeId::SInt32).value);
     auto src1 = spirv::cast<spirv::UIntValue>(
-        fragment.getVectorOperand(inst.vsrc1, TypeId::SInt32).value);
+      fragment.getVectorOperand(inst.vsrc1, TypeId::SInt32).value);
     auto sintT = fragment.context->getType(TypeId::SInt32);
 
     fragment.setVectorOperand(
-        inst.vdst, {sintT, fragment.builder.createShiftRightArithmetic(
-                               sintT, src0, src1)});
+      inst.vdst, { sintT, fragment.builder.createShiftRightArithmetic(
+                             sintT, src0, src1) });
     break;
   }
 
   case Vop2::Op::V_ASHRREV_I32: {
     auto src0 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.src0, TypeId::SInt32).value);
+      fragment.getScalarOperand(inst.src0, TypeId::SInt32).value);
     auto src1 = spirv::cast<spirv::UIntValue>(
-        fragment.getVectorOperand(inst.vsrc1, TypeId::SInt32).value);
+      fragment.getVectorOperand(inst.vsrc1, TypeId::SInt32).value);
     auto sintT = fragment.context->getType(TypeId::SInt32);
 
     fragment.setVectorOperand(
-        inst.vdst, {sintT, fragment.builder.createShiftRightArithmetic(
-                               sintT, src1, src0)});
+      inst.vdst, { sintT, fragment.builder.createShiftRightArithmetic(
+                             sintT, src1, src0) });
     break;
   }
 
@@ -1030,7 +1030,7 @@ void convertVop2(Fragment &fragment, Vop2 inst) {
 
     auto uint32T = fragment.context->getUInt32Type();
     auto result = fragment.builder.createSelect(uint32T, cmp, src1, src0);
-    fragment.setVectorOperand(inst.vdst, {uint32T, result});
+    fragment.setVectorOperand(inst.vdst, { uint32T, result });
     break;
   }
 
@@ -1044,304 +1044,304 @@ void convertSop2(Fragment &fragment, Sop2 inst) {
   switch (inst.op) {
   case Sop2::Op::S_ADD_U32: {
     auto src0 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.ssrc0, TypeId::UInt32).value);
+      fragment.getScalarOperand(inst.ssrc0, TypeId::UInt32).value);
     auto src1 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.ssrc1, TypeId::UInt32).value);
+      fragment.getScalarOperand(inst.ssrc1, TypeId::UInt32).value);
     auto resultT = fragment.context->getUInt32Type();
     auto result = fragment.builder.createIAdd(resultT, src0, src1);
-    fragment.setScc({resultT, result});
-    fragment.setScalarOperand(inst.sdst, {resultT, result});
+    fragment.setScc({ resultT, result });
+    fragment.setScalarOperand(inst.sdst, { resultT, result });
     break;
   }
   case Sop2::Op::S_ADD_I32: {
     auto src0 = spirv::cast<spirv::SIntValue>(
-        fragment.getScalarOperand(inst.ssrc0, TypeId::SInt32).value);
+      fragment.getScalarOperand(inst.ssrc0, TypeId::SInt32).value);
     auto src1 = spirv::cast<spirv::SIntValue>(
-        fragment.getScalarOperand(inst.ssrc1, TypeId::SInt32).value);
+      fragment.getScalarOperand(inst.ssrc1, TypeId::SInt32).value);
     auto resultT = fragment.context->getSint32Type();
     auto result = fragment.builder.createIAdd(resultT, src0, src1);
-    fragment.setScc({resultT, result});
-    fragment.setScalarOperand(inst.sdst, {resultT, result});
+    fragment.setScc({ resultT, result });
+    fragment.setScalarOperand(inst.sdst, { resultT, result });
     break;
   }
 
   case Sop2::Op::S_ASHR_I32: {
     auto src0 = spirv::cast<spirv::SIntValue>(
-        fragment.getScalarOperand(inst.ssrc0, TypeId::SInt32).value);
+      fragment.getScalarOperand(inst.ssrc0, TypeId::SInt32).value);
     auto src1 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.ssrc1, TypeId::UInt32).value);
+      fragment.getScalarOperand(inst.ssrc1, TypeId::UInt32).value);
 
     auto resultT = fragment.context->getSint32Type();
     src1 = spirv::cast<spirv::UIntValue>(fragment.builder.createBitwiseAnd(
-        resultT, src1, fragment.context->getUInt32(0x3f)));
+      resultT, src1, fragment.context->getUInt32(0x3f)));
 
     auto result =
-        fragment.builder.createShiftRightArithmetic(resultT, src0, src1);
-    fragment.setScc({resultT, result});
-    fragment.setScalarOperand(inst.sdst, {resultT, result});
+      fragment.builder.createShiftRightArithmetic(resultT, src0, src1);
+    fragment.setScc({ resultT, result });
+    fragment.setScalarOperand(inst.sdst, { resultT, result });
     break;
   }
   case Sop2::Op::S_ASHR_I64: {
     auto src0 = spirv::cast<spirv::SIntValue>(
-        fragment.getScalarOperand(inst.ssrc0, TypeId::SInt64).value);
+      fragment.getScalarOperand(inst.ssrc0, TypeId::SInt64).value);
     auto src1 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.ssrc1, TypeId::UInt32).value);
+      fragment.getScalarOperand(inst.ssrc1, TypeId::UInt32).value);
 
     auto resultT = fragment.context->getSint64Type();
     src1 = spirv::cast<spirv::UIntValue>(fragment.builder.createBitwiseAnd(
-        resultT, src1, fragment.context->getUInt32(0x3f)));
+      resultT, src1, fragment.context->getUInt32(0x3f)));
 
     auto result =
-        fragment.builder.createShiftRightArithmetic(resultT, src0, src1);
-    fragment.setScc({resultT, result});
-    fragment.setScalarOperand(inst.sdst, {resultT, result});
+      fragment.builder.createShiftRightArithmetic(resultT, src0, src1);
+    fragment.setScc({ resultT, result });
+    fragment.setScalarOperand(inst.sdst, { resultT, result });
     break;
   }
 
   case Sop2::Op::S_LSHR_B32: {
     auto src0 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.ssrc0, TypeId::UInt32).value);
+      fragment.getScalarOperand(inst.ssrc0, TypeId::UInt32).value);
     auto src1 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.ssrc1, TypeId::UInt32).value);
+      fragment.getScalarOperand(inst.ssrc1, TypeId::UInt32).value);
 
     auto resultT = fragment.context->getUInt32Type();
     src1 = spirv::cast<spirv::UIntValue>(fragment.builder.createBitwiseAnd(
-        resultT, src1, fragment.context->getUInt32(0x1f)));
+      resultT, src1, fragment.context->getUInt32(0x1f)));
 
     auto result = fragment.builder.createShiftRightLogical(resultT, src0, src1);
-    fragment.setScc({resultT, result});
-    fragment.setScalarOperand(inst.sdst, {resultT, result});
+    fragment.setScc({ resultT, result });
+    fragment.setScalarOperand(inst.sdst, { resultT, result });
     break;
   }
   case Sop2::Op::S_LSHR_B64: {
     auto src0 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.ssrc0, TypeId::UInt64).value);
+      fragment.getScalarOperand(inst.ssrc0, TypeId::UInt64).value);
     auto src1 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.ssrc1, TypeId::UInt32).value);
+      fragment.getScalarOperand(inst.ssrc1, TypeId::UInt32).value);
 
     auto resultT = fragment.context->getUInt64Type();
     src1 = spirv::cast<spirv::UIntValue>(fragment.builder.createBitwiseAnd(
-        resultT, src1, fragment.context->getUInt32(0x3f)));
+      resultT, src1, fragment.context->getUInt32(0x3f)));
 
     auto result = fragment.builder.createShiftRightLogical(resultT, src0, src1);
-    fragment.setScc({resultT, result});
-    fragment.setScalarOperand(inst.sdst, {resultT, result});
+    fragment.setScc({ resultT, result });
+    fragment.setScalarOperand(inst.sdst, { resultT, result });
     break;
   }
 
   case Sop2::Op::S_LSHL_B32: {
     auto src0 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.ssrc0, TypeId::UInt32).value);
+      fragment.getScalarOperand(inst.ssrc0, TypeId::UInt32).value);
     auto src1 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.ssrc1, TypeId::UInt32).value);
+      fragment.getScalarOperand(inst.ssrc1, TypeId::UInt32).value);
 
     auto resultT = fragment.context->getUInt32Type();
     src1 = spirv::cast<spirv::UIntValue>(fragment.builder.createBitwiseAnd(
-        resultT, src1, fragment.context->getUInt32(0x1f)));
+      resultT, src1, fragment.context->getUInt32(0x1f)));
 
     auto result = fragment.builder.createShiftLeftLogical(resultT, src0, src1);
-    fragment.setScc({resultT, result});
-    fragment.setScalarOperand(inst.sdst, {resultT, result});
+    fragment.setScc({ resultT, result });
+    fragment.setScalarOperand(inst.sdst, { resultT, result });
     break;
   }
   case Sop2::Op::S_LSHL_B64: {
     auto src0 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.ssrc0, TypeId::UInt64).value);
+      fragment.getScalarOperand(inst.ssrc0, TypeId::UInt64).value);
     auto src1 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.ssrc1, TypeId::UInt64).value);
+      fragment.getScalarOperand(inst.ssrc1, TypeId::UInt64).value);
 
     auto resultT = fragment.context->getUInt64Type();
     src1 = spirv::cast<spirv::UIntValue>(fragment.builder.createBitwiseAnd(
-        resultT, src1, fragment.context->getUInt32(0x3f)));
+      resultT, src1, fragment.context->getUInt32(0x3f)));
 
     auto result = fragment.builder.createShiftLeftLogical(resultT, src0, src1);
-    fragment.setScc({resultT, result});
-    fragment.setScalarOperand(inst.sdst, {resultT, result});
+    fragment.setScc({ resultT, result });
+    fragment.setScalarOperand(inst.sdst, { resultT, result });
     break;
   }
 
   case Sop2::Op::S_CSELECT_B32: {
     auto src0 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.ssrc0, TypeId::UInt32).value);
+      fragment.getScalarOperand(inst.ssrc0, TypeId::UInt32).value);
     auto src1 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.ssrc1, TypeId::UInt32).value);
+      fragment.getScalarOperand(inst.ssrc1, TypeId::UInt32).value);
 
     auto resultT = fragment.context->getUInt32Type();
     auto result =
-        fragment.builder.createSelect(resultT, fragment.getScc(), src0, src1);
-    fragment.setScalarOperand(inst.sdst, {resultT, result});
+      fragment.builder.createSelect(resultT, fragment.getScc(), src0, src1);
+    fragment.setScalarOperand(inst.sdst, { resultT, result });
     break;
   }
 
   case Sop2::Op::S_CSELECT_B64: {
     auto src0 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.ssrc0, TypeId::UInt64).value);
+      fragment.getScalarOperand(inst.ssrc0, TypeId::UInt64).value);
     auto src1 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.ssrc1, TypeId::UInt64).value);
+      fragment.getScalarOperand(inst.ssrc1, TypeId::UInt64).value);
 
     auto resultT = fragment.context->getUInt64Type();
     auto result =
-        fragment.builder.createSelect(resultT, fragment.getScc(), src0, src1);
-    fragment.setScalarOperand(inst.sdst, {resultT, result});
+      fragment.builder.createSelect(resultT, fragment.getScc(), src0, src1);
+    fragment.setScalarOperand(inst.sdst, { resultT, result });
     break;
   }
 
   case Sop2::Op::S_MUL_I32: {
     auto src0 = spirv::cast<spirv::SIntValue>(
-        fragment.getScalarOperand(inst.ssrc0, TypeId::SInt32).value);
+      fragment.getScalarOperand(inst.ssrc0, TypeId::SInt32).value);
     auto src1 = spirv::cast<spirv::SIntValue>(
-        fragment.getScalarOperand(inst.ssrc1, TypeId::SInt32).value);
+      fragment.getScalarOperand(inst.ssrc1, TypeId::SInt32).value);
     auto resultT = fragment.context->getSint32Type();
     auto result = fragment.builder.createIMul(resultT, src0, src1);
-    fragment.setScalarOperand(inst.sdst, {resultT, result});
+    fragment.setScalarOperand(inst.sdst, { resultT, result });
     break;
   }
   case Sop2::Op::S_AND_B32: {
     auto src0 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.ssrc0, TypeId::UInt32).value);
+      fragment.getScalarOperand(inst.ssrc0, TypeId::UInt32).value);
     auto src1 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.ssrc1, TypeId::UInt32).value);
+      fragment.getScalarOperand(inst.ssrc1, TypeId::UInt32).value);
     auto resultT = fragment.context->getUInt32Type();
     auto result = fragment.builder.createBitwiseAnd(resultT, src0, src1);
-    fragment.setScc({resultT, result});
-    fragment.setScalarOperand(inst.sdst, {resultT, result});
+    fragment.setScc({ resultT, result });
+    fragment.setScalarOperand(inst.sdst, { resultT, result });
     break;
   }
   case Sop2::Op::S_ANDN2_B32: {
     auto src0 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.ssrc0, TypeId::UInt32).value);
+      fragment.getScalarOperand(inst.ssrc0, TypeId::UInt32).value);
     auto src1 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.ssrc1, TypeId::UInt32).value);
+      fragment.getScalarOperand(inst.ssrc1, TypeId::UInt32).value);
     auto resultT = fragment.context->getUInt32Type();
     auto result = fragment.builder.createBitwiseAnd(
-        resultT, src0, fragment.builder.createNot(resultT, src1));
-    fragment.setScc({resultT, result});
-    fragment.setScalarOperand(inst.sdst, {resultT, result});
+      resultT, src0, fragment.builder.createNot(resultT, src1));
+    fragment.setScc({ resultT, result });
+    fragment.setScalarOperand(inst.sdst, { resultT, result });
     break;
   }
   case Sop2::Op::S_AND_B64: {
     auto src0 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.ssrc0, TypeId::UInt64).value);
+      fragment.getScalarOperand(inst.ssrc0, TypeId::UInt64).value);
     auto src1 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.ssrc1, TypeId::UInt64).value);
+      fragment.getScalarOperand(inst.ssrc1, TypeId::UInt64).value);
     auto resultT = fragment.context->getUInt64Type();
     auto result = fragment.builder.createBitwiseAnd(resultT, src0, src1);
-    fragment.setScc({resultT, result});
-    fragment.setScalarOperand(inst.sdst, {resultT, result});
+    fragment.setScc({ resultT, result });
+    fragment.setScalarOperand(inst.sdst, { resultT, result });
     break;
   }
   case Sop2::Op::S_ANDN2_B64: {
     auto src0 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.ssrc0, TypeId::UInt64).value);
+      fragment.getScalarOperand(inst.ssrc0, TypeId::UInt64).value);
     auto src1 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.ssrc1, TypeId::UInt64).value);
+      fragment.getScalarOperand(inst.ssrc1, TypeId::UInt64).value);
     auto resultT = fragment.context->getUInt64Type();
     auto result = fragment.builder.createBitwiseAnd(
-        resultT, src0, fragment.builder.createNot(resultT, src1));
-    fragment.setScc({resultT, result});
-    fragment.setScalarOperand(inst.sdst, {resultT, result});
+      resultT, src0, fragment.builder.createNot(resultT, src1));
+    fragment.setScc({ resultT, result });
+    fragment.setScalarOperand(inst.sdst, { resultT, result });
     break;
   }
   case Sop2::Op::S_OR_B32: {
     auto src0 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.ssrc0, TypeId::UInt32).value);
+      fragment.getScalarOperand(inst.ssrc0, TypeId::UInt32).value);
     auto src1 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.ssrc1, TypeId::UInt32).value);
+      fragment.getScalarOperand(inst.ssrc1, TypeId::UInt32).value);
     auto resultT = fragment.context->getUInt32Type();
     auto result = fragment.builder.createBitwiseOr(resultT, src0, src1);
-    fragment.setScc({resultT, result});
-    fragment.setScalarOperand(inst.sdst, {resultT, result});
+    fragment.setScc({ resultT, result });
+    fragment.setScalarOperand(inst.sdst, { resultT, result });
     break;
   }
   case Sop2::Op::S_OR_B64: {
     auto src0 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.ssrc0, TypeId::UInt64).value);
+      fragment.getScalarOperand(inst.ssrc0, TypeId::UInt64).value);
     auto src1 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.ssrc1, TypeId::UInt64).value);
+      fragment.getScalarOperand(inst.ssrc1, TypeId::UInt64).value);
     auto resultT = fragment.context->getUInt64Type();
     auto result = fragment.builder.createBitwiseOr(resultT, src0, src1);
-    fragment.setScc({resultT, result});
-    fragment.setScalarOperand(inst.sdst, {resultT, result});
+    fragment.setScc({ resultT, result });
+    fragment.setScalarOperand(inst.sdst, { resultT, result });
     break;
   }
   case Sop2::Op::S_NAND_B32: {
     auto src0 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.ssrc0, TypeId::UInt32).value);
+      fragment.getScalarOperand(inst.ssrc0, TypeId::UInt32).value);
     auto src1 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.ssrc1, TypeId::UInt32).value);
+      fragment.getScalarOperand(inst.ssrc1, TypeId::UInt32).value);
     auto resultT = fragment.context->getUInt32Type();
     auto result = fragment.builder.createNot(
-        resultT, fragment.builder.createBitwiseAnd(resultT, src0, src1));
-    fragment.setScc({resultT, result});
-    fragment.setScalarOperand(inst.sdst, {resultT, result});
+      resultT, fragment.builder.createBitwiseAnd(resultT, src0, src1));
+    fragment.setScc({ resultT, result });
+    fragment.setScalarOperand(inst.sdst, { resultT, result });
     break;
   }
   case Sop2::Op::S_NAND_B64: {
     auto src0 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.ssrc0, TypeId::UInt64).value);
+      fragment.getScalarOperand(inst.ssrc0, TypeId::UInt64).value);
     auto src1 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.ssrc1, TypeId::UInt64).value);
+      fragment.getScalarOperand(inst.ssrc1, TypeId::UInt64).value);
     auto resultT = fragment.context->getUInt64Type();
     auto result = fragment.builder.createNot(
-        resultT, fragment.builder.createBitwiseAnd(resultT, src0, src1));
-    fragment.setScc({resultT, result});
-    fragment.setScalarOperand(inst.sdst, {resultT, result});
+      resultT, fragment.builder.createBitwiseAnd(resultT, src0, src1));
+    fragment.setScc({ resultT, result });
+    fragment.setScalarOperand(inst.sdst, { resultT, result });
     break;
   }
   case Sop2::Op::S_NOR_B32: {
     auto src0 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.ssrc0, TypeId::UInt32).value);
+      fragment.getScalarOperand(inst.ssrc0, TypeId::UInt32).value);
     auto src1 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.ssrc1, TypeId::UInt32).value);
+      fragment.getScalarOperand(inst.ssrc1, TypeId::UInt32).value);
     auto resultT = fragment.context->getUInt32Type();
     auto result = fragment.builder.createNot(
-        resultT, fragment.builder.createBitwiseOr(resultT, src0, src1));
-    fragment.setScc({resultT, result});
-    fragment.setScalarOperand(inst.sdst, {resultT, result});
+      resultT, fragment.builder.createBitwiseOr(resultT, src0, src1));
+    fragment.setScc({ resultT, result });
+    fragment.setScalarOperand(inst.sdst, { resultT, result });
     break;
   }
   case Sop2::Op::S_NOR_B64: {
     auto src0 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.ssrc0, TypeId::UInt64).value);
+      fragment.getScalarOperand(inst.ssrc0, TypeId::UInt64).value);
     auto src1 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.ssrc1, TypeId::UInt64).value);
+      fragment.getScalarOperand(inst.ssrc1, TypeId::UInt64).value);
     auto resultT = fragment.context->getUInt64Type();
     auto result = fragment.builder.createNot(
-        resultT, fragment.builder.createBitwiseOr(resultT, src0, src1));
-    fragment.setScc({resultT, result});
-    fragment.setScalarOperand(inst.sdst, {resultT, result});
+      resultT, fragment.builder.createBitwiseOr(resultT, src0, src1));
+    fragment.setScc({ resultT, result });
+    fragment.setScalarOperand(inst.sdst, { resultT, result });
     break;
   }
 
   case Sop2::Op::S_BFE_U32: {
     auto src0 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.ssrc0, TypeId::UInt32).value);
+      fragment.getScalarOperand(inst.ssrc0, TypeId::UInt32).value);
     auto src1 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.ssrc1, TypeId::UInt32).value);
+      fragment.getScalarOperand(inst.ssrc1, TypeId::UInt32).value);
 
     auto operandT = fragment.context->getUInt32Type();
 
     auto offset =
-        spirv::cast<spirv::UIntValue>(fragment.builder.createBitwiseAnd(
-            operandT, src1, fragment.context->getUInt32(0x1f)));
+      spirv::cast<spirv::UIntValue>(fragment.builder.createBitwiseAnd(
+        operandT, src1, fragment.context->getUInt32(0x1f)));
     auto size = spirv::cast<spirv::UIntValue>(fragment.builder.createBitwiseAnd(
-        operandT,
-        fragment.builder.createShiftRightLogical(
-            operandT, src1, fragment.context->getUInt32(16)),
-        fragment.context->getUInt32(0x7f)));
+      operandT,
+      fragment.builder.createShiftRightLogical(
+        operandT, src1, fragment.context->getUInt32(16)),
+      fragment.context->getUInt32(0x7f)));
 
     auto field =
-        fragment.builder.createShiftRightLogical(operandT, src0, offset);
+      fragment.builder.createShiftRightLogical(operandT, src0, offset);
     auto mask = fragment.builder.createISub(
-        operandT,
-        fragment.builder.createShiftLeftLogical(
-            operandT, fragment.context->getUInt32(1), size),
-        fragment.context->getUInt32(1));
+      operandT,
+      fragment.builder.createShiftLeftLogical(
+        operandT, fragment.context->getUInt32(1), size),
+      fragment.context->getUInt32(1));
 
     auto result = fragment.builder.createBitwiseAnd(operandT, field, mask);
     auto resultT = fragment.context->getUInt32Type();
-    fragment.setScc({resultT, result});
-    fragment.setScalarOperand(inst.sdst, {resultT, result});
+    fragment.setScc({ resultT, result });
+    fragment.setScalarOperand(inst.sdst, { resultT, result });
     break;
   }
 
@@ -1355,8 +1355,8 @@ void convertSopk(Fragment &fragment, Sopk inst) {
   switch (inst.op) {
   case Sopk::Op::S_MOVK_I32:
     fragment.setScalarOperand(inst.sdst,
-                              {fragment.context->getSint32Type(),
-                               fragment.context->getSInt32(inst.simm)});
+                              { fragment.context->getSint32Type(),
+                               fragment.context->getSInt32(inst.simm) });
     break;
   default:
     inst.dump();
@@ -1379,15 +1379,15 @@ void convertSmrd(Fragment &fragment, Smrd inst) {
     }
 
     auto result = fragment.builder.createUDiv(
-        resultT, spirv::cast<spirv::UIntValue>(resultV),
-        fragment.context->getUInt32(4));
+      resultT, spirv::cast<spirv::UIntValue>(resultV),
+      fragment.context->getUInt32(4));
 
     if (adv != 0) {
       result = fragment.builder.createIAdd(resultT, result,
                                            fragment.context->getUInt32(adv));
     }
     return result;
-  };
+    };
 
   switch (inst.op) {
   case Smrd::Op::S_BUFFER_LOAD_DWORD:
@@ -1396,16 +1396,16 @@ void convertSmrd(Fragment &fragment, Smrd inst) {
   case Smrd::Op::S_BUFFER_LOAD_DWORDX8:
   case Smrd::Op::S_BUFFER_LOAD_DWORDX16: {
     std::uint32_t count = 1
-                          << (static_cast<int>(inst.op) -
-                              static_cast<int>(Smrd::Op::S_BUFFER_LOAD_DWORD));
+      << (static_cast<int>(inst.op) -
+          static_cast<int>(Smrd::Op::S_BUFFER_LOAD_DWORD));
     auto vBuffer0 =
-        fragment.getScalarOperand((inst.sbase << 1) + 0, TypeId::UInt32);
+      fragment.getScalarOperand((inst.sbase << 1) + 0, TypeId::UInt32);
     auto vBuffer1 =
-        fragment.getScalarOperand((inst.sbase << 1) + 1, TypeId::UInt32);
+      fragment.getScalarOperand((inst.sbase << 1) + 1, TypeId::UInt32);
     auto vBuffer2 =
-        fragment.getScalarOperand((inst.sbase << 1) + 2, TypeId::UInt32);
+      fragment.getScalarOperand((inst.sbase << 1) + 2, TypeId::UInt32);
     auto vBuffer3 =
-        fragment.getScalarOperand((inst.sbase << 1) + 3, TypeId::UInt32);
+      fragment.getScalarOperand((inst.sbase << 1) + 3, TypeId::UInt32);
 
     auto optVBuffer0Value = fragment.context->findUint32Value(vBuffer0.value);
     auto optVBuffer1Value = fragment.context->findUint32Value(vBuffer1.value);
@@ -1414,26 +1414,26 @@ void convertSmrd(Fragment &fragment, Smrd inst) {
 
     if (optVBuffer0Value && optVBuffer1Value && optVBuffer2Value &&
         optVBuffer3Value) {
-      std::uint32_t vBufferData[] = {*optVBuffer0Value, *optVBuffer1Value,
-                                     *optVBuffer2Value, *optVBuffer3Value};
+      std::uint32_t vBufferData[] = { *optVBuffer0Value, *optVBuffer1Value,
+                                     *optVBuffer2Value, *optVBuffer3Value };
       auto vbuffer = reinterpret_cast<GnmVBuffer *>(vBufferData);
       // std::printf("vBuffer address = %lx\n", vbuffer->getAddress());
 
       auto valueT = fragment.context->getFloat32Type();
       auto uniform = fragment.context->getOrCreateStorageBuffer(
-          vBufferData, TypeId::Float32);
+        vBufferData, TypeId::Float32);
       uniform->accessOp |= AccessOp::Load;
       auto storageBufferPointerType = fragment.context->getPointerType(
-          spv::StorageClass::StorageBuffer, TypeId::Float32);
+        spv::StorageClass::StorageBuffer, TypeId::Float32);
 
       for (std::uint32_t i = 0; i < count; ++i) {
         auto storageBufferPointerValue = fragment.builder.createAccessChain(
-            storageBufferPointerType, uniform->variable,
-            {{fragment.context->getUInt32(0), getOffset(i)}});
+          storageBufferPointerType, uniform->variable,
+          { {fragment.context->getUInt32(0), getOffset(i)} });
 
         auto value =
-            fragment.builder.createLoad(valueT, storageBufferPointerValue);
-        fragment.setScalarOperand(inst.sdst + i, {valueT, value});
+          fragment.builder.createLoad(valueT, storageBufferPointerValue);
+        fragment.setScalarOperand(inst.sdst + i, { valueT, value });
       }
     } else {
       // FIXME: implement runtime V# buffer fetching
@@ -1453,7 +1453,7 @@ void convertSmrd(Fragment &fragment, Smrd inst) {
     auto uint32T = fragment.context->getUInt32Type();
     auto sgprLo = fragment.getScalarOperand(inst.sbase << 1, TypeId::UInt32);
     auto sgprHi =
-        fragment.getScalarOperand((inst.sbase << 1) + 1, TypeId::UInt32);
+      fragment.getScalarOperand((inst.sbase << 1) + 1, TypeId::UInt32);
     auto optLoAddress = fragment.context->findUint32Value(sgprLo.value);
     auto optHiAddress = fragment.context->findUint32Value(sgprHi.value);
 
@@ -1461,13 +1461,13 @@ void convertSmrd(Fragment &fragment, Smrd inst) {
       // if it is imm and address is known, read the values now
       auto memory = fragment.context->getMemory();
       auto address =
-          *optLoAddress | (static_cast<std::uint64_t>(*optHiAddress) << 32);
+        *optLoAddress | (static_cast<std::uint64_t>(*optHiAddress) << 32);
 
       auto data =
-          memory.getPointer<std::uint32_t>(address + (inst.offset << 2));
+        memory.getPointer<std::uint32_t>(address + (inst.offset << 2));
       for (std::uint32_t i = 0; i < count; ++i) {
         fragment.setScalarOperand(
-            inst.sdst + i, {uint32T, fragment.context->getUInt32(data[i])});
+          inst.sdst + i, { uint32T, fragment.context->getUInt32(data[i]) });
       }
     } else {
       // FIXME: implement
@@ -1489,75 +1489,75 @@ void convertVop3(Fragment &fragment, Vop3 inst) {
   auto applyOmod = [&](Value result) -> Value {
     switch (inst.omod) {
     case 1:
-      return {result.type, fragment.builder.createFMul(
+      return { result.type, fragment.builder.createFMul(
                                spirv::cast<spirv::FloatType>(result.type),
                                spirv::cast<spirv::FloatValue>(result.value),
-                               fragment.context->getFloat32(2))};
+                               fragment.context->getFloat32(2)) };
 
     case 2:
-      return {result.type, fragment.builder.createFMul(
+      return { result.type, fragment.builder.createFMul(
                                spirv::cast<spirv::FloatType>(result.type),
                                spirv::cast<spirv::FloatValue>(result.value),
-                               fragment.context->getFloat32(4))};
+                               fragment.context->getFloat32(4)) };
     case 3:
-      return {result.type, fragment.builder.createFDiv(
+      return { result.type, fragment.builder.createFDiv(
                                spirv::cast<spirv::FloatType>(result.type),
                                spirv::cast<spirv::FloatValue>(result.value),
-                               fragment.context->getFloat32(2))};
+                               fragment.context->getFloat32(2)) };
 
     default:
     case 0:
       return result;
     }
-  };
+    };
 
   auto applyClamp = [&](Value result) -> Value {
     if (inst.clmp) {
       auto glslStd450 = fragment.context->getGlslStd450();
       result.value = fragment.builder.createExtInst(
-          result.type, glslStd450, GLSLstd450FClamp,
-          {{result.value, fragment.context->getFloat32(0),
-            fragment.context->getFloat32(1)}});
+        result.type, glslStd450, GLSLstd450FClamp,
+        { {result.value, fragment.context->getFloat32(0),
+          fragment.context->getFloat32(1)} });
     }
 
     return result;
-  };
+    };
 
   auto getSrc = [&](int index, TypeId type) -> Value {
     std::uint32_t src =
-        index == 0 ? inst.src0 : (index == 1 ? inst.src1 : inst.src2);
+      index == 0 ? inst.src0 : (index == 1 ? inst.src1 : inst.src2);
 
     auto result = fragment.getScalarOperand(src, type);
 
     if (inst.abs & (1 << index)) {
       auto glslStd450 = fragment.context->getGlslStd450();
       result.value = fragment.builder.createExtInst(
-          result.type, glslStd450, GLSLstd450FAbs, {{result.value}});
+        result.type, glslStd450, GLSLstd450FAbs, { {result.value} });
     }
 
     if (inst.neg & (1 << index)) {
       result.value = fragment.builder.createFNegate(
-          spirv::cast<spirv::FloatType>(result.type),
-          spirv::cast<spirv::FloatValue>(result.value));
+        spirv::cast<spirv::FloatType>(result.type),
+        spirv::cast<spirv::FloatValue>(result.value));
     }
 
     return result;
-  };
+    };
 
   auto getSdstSrc = [&](int index, TypeId type) -> Value {
     std::uint32_t src =
-        index == 0 ? inst.src0 : (index == 1 ? inst.src1 : inst.src2);
+      index == 0 ? inst.src0 : (index == 1 ? inst.src1 : inst.src2);
 
     auto result = fragment.getScalarOperand(src, type);
 
     if (inst.neg & (1 << index)) {
       result.value = fragment.builder.createFNegate(
-          spirv::cast<spirv::FloatType>(result.type),
-          spirv::cast<spirv::FloatValue>(result.value));
+        spirv::cast<spirv::FloatType>(result.type),
+        spirv::cast<spirv::FloatValue>(result.value));
     }
 
     return result;
-  };
+    };
 
   auto cmpOp = [&](TypeId type, CmpKind kind, CmpFlags flags = CmpFlags::None) {
     auto src0 = fragment.getScalarOperand(inst.src0, type).value;
@@ -1565,9 +1565,9 @@ void convertVop3(Fragment &fragment, Vop3 inst) {
 
     auto result = doCmpOp(fragment, type, src0, src1, kind, flags);
     fragment.setScalarOperand(inst.vdst, result);
-    fragment.setScalarOperand(inst.vdst + 1, {fragment.context->getUInt32Type(),
-                                              fragment.context->getUInt32(0)});
-  };
+    fragment.setScalarOperand(inst.vdst + 1, { fragment.context->getUInt32Type(),
+                                              fragment.context->getUInt32(0) });
+    };
 
   switch (inst.op) {
   case Vop3::Op::V3_CMP_F_F32:
@@ -1978,8 +1978,8 @@ void convertVop3(Fragment &fragment, Vop3 inst) {
   case Vop3::Op::V3_CMP_T_I32:
     cmpOp(TypeId::SInt32, CmpKind::T);
     break;
-  // case Vop3::Op::V3_CMP_CLASS_F32: cmpOp(TypeId::Float32, CmpKind::CLASS);
-  // break;
+    // case Vop3::Op::V3_CMP_CLASS_F32: cmpOp(TypeId::Float32, CmpKind::CLASS);
+    // break;
   case Vop3::Op::V3_CMP_LT_I16:
     cmpOp(TypeId::SInt16, CmpKind::LT);
     break;
@@ -1998,8 +1998,8 @@ void convertVop3(Fragment &fragment, Vop3 inst) {
   case Vop3::Op::V3_CMP_GE_I16:
     cmpOp(TypeId::SInt16, CmpKind::GE);
     break;
-  // case Vop3::Op::V3_CMP_CLASS_F16: cmpOp(TypeId::Float16, CmpKind::CLASS);
-  // break;
+    // case Vop3::Op::V3_CMP_CLASS_F16: cmpOp(TypeId::Float16, CmpKind::CLASS);
+    // break;
   case Vop3::Op::V3_CMPX_F_I32:
     cmpOp(TypeId::SInt32, CmpKind::F, CmpFlags::X);
     break;
@@ -2024,8 +2024,8 @@ void convertVop3(Fragment &fragment, Vop3 inst) {
   case Vop3::Op::V3_CMPX_T_I32:
     cmpOp(TypeId::SInt32, CmpKind::T, CmpFlags::X);
     break;
-  // case Vop3::Op::V3_CMPX_CLASS_F32: cmpOp(TypeId::Float32, CmpKind::CLASS,
-  // CmpFlags::X); break;
+    // case Vop3::Op::V3_CMPX_CLASS_F32: cmpOp(TypeId::Float32, CmpKind::CLASS,
+    // CmpFlags::X); break;
   case Vop3::Op::V3_CMPX_LT_I16:
     cmpOp(TypeId::SInt16, CmpKind::LT, CmpFlags::X);
     break;
@@ -2044,8 +2044,8 @@ void convertVop3(Fragment &fragment, Vop3 inst) {
   case Vop3::Op::V3_CMPX_GE_I16:
     cmpOp(TypeId::SInt16, CmpKind::GE, CmpFlags::X);
     break;
-  // case Vop3::Op::V3_CMPX_CLASS_F16: cmpOp(TypeId::Float16, CmpKind::CLASS,
-  // CmpFlags::X); break;
+    // case Vop3::Op::V3_CMPX_CLASS_F16: cmpOp(TypeId::Float16, CmpKind::CLASS,
+    // CmpFlags::X); break;
   case Vop3::Op::V3_CMP_F_I64:
     cmpOp(TypeId::SInt64, CmpKind::F);
     break;
@@ -2070,8 +2070,8 @@ void convertVop3(Fragment &fragment, Vop3 inst) {
   case Vop3::Op::V3_CMP_T_I64:
     cmpOp(TypeId::SInt64, CmpKind::T);
     break;
-  // case Vop3::Op::V3_CMP_CLASS_F64: cmpOp(TypeId::Float64, CmpKind::CLASS);
-  // break;
+    // case Vop3::Op::V3_CMP_CLASS_F64: cmpOp(TypeId::Float64, CmpKind::CLASS);
+    // break;
   case Vop3::Op::V3_CMP_LT_U16:
     cmpOp(TypeId::UInt16, CmpKind::LT);
     break;
@@ -2114,8 +2114,8 @@ void convertVop3(Fragment &fragment, Vop3 inst) {
   case Vop3::Op::V3_CMPX_T_I64:
     cmpOp(TypeId::SInt64, CmpKind::T, CmpFlags::X);
     break;
-  // case Vop3::Op::V3_CMPX_CLASS_F64: cmpOp(TypeId::Float64, CmpKind::CLASS,
-  // CmpFlags::X); break;
+    // case Vop3::Op::V3_CMPX_CLASS_F64: cmpOp(TypeId::Float64, CmpKind::CLASS,
+    // CmpFlags::X); break;
   case Vop3::Op::V3_CMPX_LT_U16:
     cmpOp(TypeId::UInt16, CmpKind::LT, CmpFlags::X);
     break;
@@ -2308,8 +2308,8 @@ void convertVop3(Fragment &fragment, Vop3 inst) {
     auto floatT = fragment.context->getFloat32Type();
     auto float1 = fragment.context->getFloat32(1);
     auto resultValue = fragment.builder.createFDiv(
-        floatT, float1, spirv::cast<spirv::FloatValue>(src.value));
-    auto result = applyClamp(applyOmod({floatT, resultValue}));
+      floatT, float1, spirv::cast<spirv::FloatValue>(src.value));
+    auto result = applyClamp(applyOmod({ floatT, resultValue }));
 
     fragment.setVectorOperand(inst.vdst, result);
     break;
@@ -2320,16 +2320,16 @@ void convertVop3(Fragment &fragment, Vop3 inst) {
     auto src1 = fragment.getScalarOperand(inst.src1, TypeId::UInt32).value;
     auto uintT = fragment.context->getType(TypeId::UInt32);
     auto resultStruct =
-        fragment.context->getStructType(std::array{uintT, uintT});
+      fragment.context->getStructType(std::array{ uintT, uintT });
     auto result = fragment.builder.createIAddCarry(resultStruct, src0, src1);
     fragment.setVectorOperand(
-        inst.vdst,
-        {uintT, fragment.builder.createCompositeExtract(
-                    uintT, result, std::array{static_cast<std::uint32_t>(0)})});
+      inst.vdst,
+      { uintT, fragment.builder.createCompositeExtract(
+                  uintT, result, std::array{static_cast<std::uint32_t>(0)}) });
     fragment.setScalarOperand(
-        inst.sdst,
-        {uintT, fragment.builder.createCompositeExtract(
-                    uintT, result, std::array{static_cast<std::uint32_t>(1)})});
+      inst.sdst,
+      { uintT, fragment.builder.createCompositeExtract(
+                  uintT, result, std::array{static_cast<std::uint32_t>(1)}) });
     // TODO: update sdst + 1
     break;
   }
@@ -2339,9 +2339,9 @@ void convertVop3(Fragment &fragment, Vop3 inst) {
     auto src0 = getSrc(0, TypeId::Float32);
     auto src1 = getSrc(1, TypeId::Float32);
     auto resultValue = fragment.builder.createFAdd(
-        floatT, spirv::cast<spirv::FloatValue>(src0.value),
-        spirv::cast<spirv::FloatValue>(src1.value));
-    auto result = applyClamp(applyOmod({floatT, resultValue}));
+      floatT, spirv::cast<spirv::FloatValue>(src0.value),
+      spirv::cast<spirv::FloatValue>(src1.value));
+    auto result = applyClamp(applyOmod({ floatT, resultValue }));
 
     fragment.setVectorOperand(inst.vdst, result);
     break;
@@ -2352,9 +2352,9 @@ void convertVop3(Fragment &fragment, Vop3 inst) {
     auto src0 = getSrc(0, TypeId::Float32);
     auto src1 = getSrc(1, TypeId::Float32);
     auto resultValue = fragment.builder.createFSub(
-        floatT, spirv::cast<spirv::FloatValue>(src0.value),
-        spirv::cast<spirv::FloatValue>(src1.value));
-    auto result = applyClamp(applyOmod({floatT, resultValue}));
+      floatT, spirv::cast<spirv::FloatValue>(src0.value),
+      spirv::cast<spirv::FloatValue>(src1.value));
+    auto result = applyClamp(applyOmod({ floatT, resultValue }));
 
     fragment.setVectorOperand(inst.vdst, result);
     break;
@@ -2365,9 +2365,9 @@ void convertVop3(Fragment &fragment, Vop3 inst) {
     auto src0 = getSrc(0, TypeId::Float32);
     auto src1 = getSrc(1, TypeId::Float32);
     auto resultValue = fragment.builder.createFMul(
-        floatT, spirv::cast<spirv::FloatValue>(src0.value),
-        spirv::cast<spirv::FloatValue>(src1.value));
-    auto result = applyClamp(applyOmod({floatT, resultValue}));
+      floatT, spirv::cast<spirv::FloatValue>(src0.value),
+      spirv::cast<spirv::FloatValue>(src1.value));
+    auto result = applyClamp(applyOmod({ floatT, resultValue }));
 
     fragment.setVectorOperand(inst.vdst, result);
     break;
@@ -2377,9 +2377,9 @@ void convertVop3(Fragment &fragment, Vop3 inst) {
     auto src0 = getSrc(0, TypeId::SInt32);
     auto src1 = getSrc(1, TypeId::SInt32);
     auto resultValue = fragment.builder.createIMul(
-        resultT, spirv::cast<spirv::SIntValue>(src0.value),
-        spirv::cast<spirv::SIntValue>(src1.value));
-    auto result = applyClamp(applyOmod({resultT, resultValue}));
+      resultT, spirv::cast<spirv::SIntValue>(src0.value),
+      spirv::cast<spirv::SIntValue>(src1.value));
+    auto result = applyClamp(applyOmod({ resultT, resultValue }));
 
     fragment.setVectorOperand(inst.vdst, result);
     break;
@@ -2392,18 +2392,18 @@ void convertVop3(Fragment &fragment, Vop3 inst) {
     auto sint64T = fragment.context->getSint64Type();
 
     auto src0_64 = fragment.builder.createSConvert(
-        sint64T, spirv::cast<spirv::SIntValue>(src0.value));
+      sint64T, spirv::cast<spirv::SIntValue>(src0.value));
     auto src1_64 = fragment.builder.createSConvert(
-        sint64T, spirv::cast<spirv::SIntValue>(src1.value));
+      sint64T, spirv::cast<spirv::SIntValue>(src1.value));
 
     auto resultValue64 = fragment.builder.createIMul(
-        sint64T, spirv::cast<spirv::SIntValue>(src0_64),
-        spirv::cast<spirv::SIntValue>(src1_64));
+      sint64T, spirv::cast<spirv::SIntValue>(src0_64),
+      spirv::cast<spirv::SIntValue>(src1_64));
 
     resultValue64 = fragment.builder.createShiftRightLogical(
-        sint64T, resultValue64, fragment.context->getUInt32(32));
+      sint64T, resultValue64, fragment.context->getUInt32(32));
     auto resultValue = fragment.builder.createSConvert(resultT, resultValue64);
-    auto result = applyClamp(applyOmod({resultT, resultValue}));
+    auto result = applyClamp(applyOmod({ resultT, resultValue }));
 
     fragment.setVectorOperand(inst.vdst, result);
     break;
@@ -2421,9 +2421,9 @@ void convertVop3(Fragment &fragment, Vop3 inst) {
     auto resultValue64 = fragment.builder.createIMul(uint64T, src0_64, src1_64);
 
     resultValue64 = fragment.builder.createShiftRightLogical(
-        uint64T, resultValue64, fragment.context->getUInt32(32));
+      uint64T, resultValue64, fragment.context->getUInt32(32));
     auto resultValue = fragment.builder.createUConvert(resultT, resultValue64);
-    auto result = applyClamp(applyOmod({resultT, resultValue}));
+    auto result = applyClamp(applyOmod({ resultT, resultValue }));
 
     fragment.setVectorOperand(inst.vdst, result);
     break;
@@ -2435,117 +2435,117 @@ void convertVop3(Fragment &fragment, Vop3 inst) {
     auto src1 = getSrc(1, TypeId::Float32);
 
     auto dst = spirv::cast<spirv::FloatValue>( // FIXME: should use src2?
-        fragment.getVectorOperand(inst.vdst, TypeId::Float32).value);
+                                              fragment.getVectorOperand(inst.vdst, TypeId::Float32).value);
 
     auto resultValue = fragment.builder.createFAdd(
-        floatT,
-        fragment.builder.createFMul(floatT,
-                                    spirv::cast<spirv::FloatValue>(src0.value),
-                                    spirv::cast<spirv::FloatValue>(src1.value)),
-        dst);
+      floatT,
+      fragment.builder.createFMul(floatT,
+                                  spirv::cast<spirv::FloatValue>(src0.value),
+                                  spirv::cast<spirv::FloatValue>(src1.value)),
+      dst);
 
-    auto result = applyClamp(applyOmod({floatT, resultValue}));
+    auto result = applyClamp(applyOmod({ floatT, resultValue }));
 
     fragment.setVectorOperand(inst.vdst, result);
     break;
   }
   case Vop3::Op::V3_MAD_U32_U24: {
     auto src0 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.src0, TypeId::UInt32).value);
+      fragment.getScalarOperand(inst.src0, TypeId::UInt32).value);
     auto src1 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.src1, TypeId::UInt32).value);
+      fragment.getScalarOperand(inst.src1, TypeId::UInt32).value);
     auto src2 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.src2, TypeId::UInt32).value);
+      fragment.getScalarOperand(inst.src2, TypeId::UInt32).value);
     auto operandT = fragment.context->getUInt32Type();
 
     src0 = spirv::cast<spirv::UIntValue>(fragment.builder.createBitwiseAnd(
-        operandT, src0, fragment.context->getUInt32((1 << 24) - 1)));
+      operandT, src0, fragment.context->getUInt32((1 << 24) - 1)));
     src1 = spirv::cast<spirv::UIntValue>(fragment.builder.createBitwiseAnd(
-        operandT, src1, fragment.context->getUInt32((1 << 24) - 1)));
+      operandT, src1, fragment.context->getUInt32((1 << 24) - 1)));
 
     auto result = fragment.builder.createIAdd(
-        operandT, fragment.builder.createIMul(operandT, src0, src1), src2);
+      operandT, fragment.builder.createIMul(operandT, src0, src1), src2);
 
-    fragment.setVectorOperand(inst.vdst, {operandT, result});
+    fragment.setVectorOperand(inst.vdst, { operandT, result });
     break;
   }
   case Vop3::Op::V3_MAD_I32_I24: {
     auto src0 = spirv::cast<spirv::SIntValue>(
-        fragment.getScalarOperand(inst.src0, TypeId::SInt32).value);
+      fragment.getScalarOperand(inst.src0, TypeId::SInt32).value);
     auto src1 = spirv::cast<spirv::SIntValue>(
-        fragment.getScalarOperand(inst.src1, TypeId::SInt32).value);
+      fragment.getScalarOperand(inst.src1, TypeId::SInt32).value);
     auto src2 = spirv::cast<spirv::SIntValue>(
-        fragment.getScalarOperand(inst.src2, TypeId::SInt32).value);
+      fragment.getScalarOperand(inst.src2, TypeId::SInt32).value);
     auto operandT = fragment.context->getSint32Type();
 
     src0 = fragment.builder.createShiftLeftLogical(
-        operandT, src0, fragment.context->getUInt32(8));
+      operandT, src0, fragment.context->getUInt32(8));
     src0 = fragment.builder.createShiftRightArithmetic(
-        operandT, src0, fragment.context->getUInt32(8));
+      operandT, src0, fragment.context->getUInt32(8));
     src1 = fragment.builder.createShiftLeftLogical(
-        operandT, src1, fragment.context->getUInt32(8));
+      operandT, src1, fragment.context->getUInt32(8));
     src1 = fragment.builder.createShiftRightArithmetic(
-        operandT, src1, fragment.context->getUInt32(8));
+      operandT, src1, fragment.context->getUInt32(8));
 
     auto result = fragment.builder.createIAdd(
-        operandT, fragment.builder.createIMul(operandT, src0, src1), src2);
+      operandT, fragment.builder.createIMul(operandT, src0, src1), src2);
 
-    fragment.setVectorOperand(inst.vdst, {operandT, result});
+    fragment.setVectorOperand(inst.vdst, { operandT, result });
     break;
   }
   case Vop3::Op::V3_MUL_U32_U24: {
     auto src0 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.src0, TypeId::UInt32).value);
+      fragment.getScalarOperand(inst.src0, TypeId::UInt32).value);
     auto src1 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.src1, TypeId::UInt32).value);
+      fragment.getScalarOperand(inst.src1, TypeId::UInt32).value);
     auto operandT = fragment.context->getUInt32Type();
 
     src0 = spirv::cast<spirv::UIntValue>(fragment.builder.createBitwiseAnd(
-        operandT, src0, fragment.context->getUInt32((1 << 24) - 1)));
+      operandT, src0, fragment.context->getUInt32((1 << 24) - 1)));
     src1 = spirv::cast<spirv::UIntValue>(fragment.builder.createBitwiseAnd(
-        operandT, src1, fragment.context->getUInt32((1 << 24) - 1)));
+      operandT, src1, fragment.context->getUInt32((1 << 24) - 1)));
 
     auto result = fragment.builder.createIMul(operandT, src0, src1);
 
-    fragment.setVectorOperand(inst.vdst, {operandT, result});
+    fragment.setVectorOperand(inst.vdst, { operandT, result });
     break;
   }
   case Vop3::Op::V3_MUL_I32_I24: {
     auto src0 = spirv::cast<spirv::SIntValue>(
-        fragment.getScalarOperand(inst.src0, TypeId::SInt32).value);
+      fragment.getScalarOperand(inst.src0, TypeId::SInt32).value);
     auto src1 = spirv::cast<spirv::SIntValue>(
-        fragment.getScalarOperand(inst.src1, TypeId::SInt32).value);
+      fragment.getScalarOperand(inst.src1, TypeId::SInt32).value);
     auto src2 = spirv::cast<spirv::SIntValue>(
-        fragment.getScalarOperand(inst.src2, TypeId::SInt32).value);
+      fragment.getScalarOperand(inst.src2, TypeId::SInt32).value);
     auto operandT = fragment.context->getSint32Type();
 
     src0 = fragment.builder.createShiftLeftLogical(
-        operandT, src0, fragment.context->getUInt32(8));
+      operandT, src0, fragment.context->getUInt32(8));
     src0 = fragment.builder.createShiftRightArithmetic(
-        operandT, src0, fragment.context->getUInt32(8));
+      operandT, src0, fragment.context->getUInt32(8));
     src1 = fragment.builder.createShiftLeftLogical(
-        operandT, src1, fragment.context->getUInt32(8));
+      operandT, src1, fragment.context->getUInt32(8));
     src1 = fragment.builder.createShiftRightArithmetic(
-        operandT, src1, fragment.context->getUInt32(8));
+      operandT, src1, fragment.context->getUInt32(8));
 
     auto result = fragment.builder.createIMul(operandT, src0, src1);
 
-    fragment.setVectorOperand(inst.vdst, {operandT, result});
+    fragment.setVectorOperand(inst.vdst, { operandT, result });
     break;
   }
   case Vop3::Op::V3_MAD_F32: {
     auto src0 = spirv::cast<spirv::FloatValue>(
-        fragment.getScalarOperand(inst.src0, TypeId::Float32).value);
+      fragment.getScalarOperand(inst.src0, TypeId::Float32).value);
     auto src1 = spirv::cast<spirv::FloatValue>(
-        fragment.getScalarOperand(inst.src1, TypeId::Float32).value);
+      fragment.getScalarOperand(inst.src1, TypeId::Float32).value);
     auto src2 = spirv::cast<spirv::FloatValue>(
-        fragment.getScalarOperand(inst.src2, TypeId::Float32).value);
+      fragment.getScalarOperand(inst.src2, TypeId::Float32).value);
     auto floatT = fragment.context->getFloat32Type();
 
     auto result = fragment.builder.createFAdd(
-        floatT, fragment.builder.createFMul(floatT, src0, src1), src2);
+      floatT, fragment.builder.createFMul(floatT, src0, src1), src2);
 
-    fragment.setVectorOperand(inst.vdst, {floatT, result});
+    fragment.setVectorOperand(inst.vdst, { floatT, result });
     break;
   }
   case Vop3::Op::V3_CNDMASK_B32: {
@@ -2554,46 +2554,46 @@ void convertVop3(Fragment &fragment, Vop3 inst) {
     auto src2 = fragment.getScalarOperand(inst.src2, TypeId::UInt32).value;
 
     auto cmp = fragment.builder.createINotEqual(
-        fragment.context->getBoolType(), src2, fragment.context->getUInt32(0));
+      fragment.context->getBoolType(), src2, fragment.context->getUInt32(0));
 
     auto uint32T = fragment.context->getUInt32Type();
     auto result = fragment.builder.createSelect(uint32T, cmp, src1, src0);
-    fragment.setVectorOperand(inst.vdst, {uint32T, result});
+    fragment.setVectorOperand(inst.vdst, { uint32T, result });
     break;
   }
 
   case Vop3::Op::V3_BFE_U32: {
     auto src0 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.src0, TypeId::UInt32).value);
+      fragment.getScalarOperand(inst.src0, TypeId::UInt32).value);
     auto src1 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.src1, TypeId::UInt32).value);
+      fragment.getScalarOperand(inst.src1, TypeId::UInt32).value);
     auto src2 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.src2, TypeId::UInt32).value);
+      fragment.getScalarOperand(inst.src2, TypeId::UInt32).value);
 
     auto operandT = fragment.context->getUInt32Type();
 
     auto voffset =
-        spirv::cast<spirv::UIntValue>(fragment.builder.createBitwiseAnd(
-            operandT, src1, fragment.context->getUInt32(0x1f)));
+      spirv::cast<spirv::UIntValue>(fragment.builder.createBitwiseAnd(
+        operandT, src1, fragment.context->getUInt32(0x1f)));
     auto vsize =
-        spirv::cast<spirv::UIntValue>(fragment.builder.createBitwiseAnd(
-            operandT, src2, fragment.context->getUInt32(0x1f)));
+      spirv::cast<spirv::UIntValue>(fragment.builder.createBitwiseAnd(
+        operandT, src2, fragment.context->getUInt32(0x1f)));
     auto field =
-        fragment.builder.createShiftRightLogical(operandT, src0, voffset);
+      fragment.builder.createShiftRightLogical(operandT, src0, voffset);
     auto mask = fragment.builder.createISub(
-        operandT,
-        fragment.builder.createShiftLeftLogical(
-            operandT, fragment.context->getUInt32(1), vsize),
-        fragment.context->getUInt32(1));
+      operandT,
+      fragment.builder.createShiftLeftLogical(
+        operandT, fragment.context->getUInt32(1), vsize),
+      fragment.context->getUInt32(1));
 
     auto resultT = fragment.context->getUInt32Type();
     auto result = fragment.builder.createSelect(
-        operandT,
-        fragment.builder.createIEqual(fragment.context->getBoolType(), vsize,
-                                      fragment.context->getUInt32(0)),
-        fragment.context->getUInt32(0),
-        fragment.builder.createBitwiseAnd(operandT, field, mask));
-    fragment.setVectorOperand(inst.vdst, {resultT, result});
+      operandT,
+      fragment.builder.createIEqual(fragment.context->getBoolType(), vsize,
+                                    fragment.context->getUInt32(0)),
+      fragment.context->getUInt32(0),
+      fragment.builder.createBitwiseAnd(operandT, field, mask));
+    fragment.setVectorOperand(inst.vdst, { resultT, result });
     break;
   }
 
@@ -2606,11 +2606,11 @@ void convertVop3(Fragment &fragment, Vop3 inst) {
     auto src1 = fragment.getScalarOperand(inst.src1, TypeId::Float32).value;
 
     auto src = fragment.builder.createCompositeConstruct(
-        float2T, std::array{src0, src1});
+      float2T, std::array{ src0, src1 });
     auto dst = fragment.builder.createExtInst(
-        uintT, glslStd450, GLSLstd450PackHalf2x16, std::array{src});
+      uintT, glslStd450, GLSLstd450PackHalf2x16, std::array{ src });
 
-    fragment.setVectorOperand(inst.vdst, {uintT, dst});
+    fragment.setVectorOperand(inst.vdst, { uintT, dst });
     break;
   }
 
@@ -2627,11 +2627,11 @@ void convertVop3(Fragment &fragment, Vop3 inst) {
 
     auto glslStd450 = fragment.context->getGlslStd450();
     auto sabsdiff = fragment.builder.createExtInst(sint32T, glslStd450,
-                                                   GLSLstd450SAbs, {{sdiff}});
+                                                   GLSLstd450SAbs, { {sdiff} });
 
     auto absdiff = fragment.builder.createBitcast(uint32T, sabsdiff);
     auto result = fragment.builder.createIAdd(uint32T, absdiff, src2);
-    fragment.setVectorOperand(inst.vdst, {uint32T, result});
+    fragment.setVectorOperand(inst.vdst, { uint32T, result });
     break;
   }
 
@@ -2656,7 +2656,7 @@ void convertMubuf(Fragment &fragment, Mubuf inst) {
   auto getSOffset = [&](std::int32_t adv = 0) -> spirv::UIntValue {
     auto resultT = fragment.context->getUInt32Type();
     auto resultV =
-        fragment.getScalarOperand(inst.soffset, TypeId::UInt32).value;
+      fragment.getScalarOperand(inst.soffset, TypeId::UInt32).value;
     auto result = spirv::cast<spirv::UIntValue>(resultV);
 
     if (adv != 0) {
@@ -2669,17 +2669,17 @@ void convertMubuf(Fragment &fragment, Mubuf inst) {
     }
 
     return result;
-  };
+    };
 
   auto getVBuffer = [&] {
     auto vBuffer0 =
-        fragment.getScalarOperand((inst.srsrc << 2) + 0, TypeId::UInt32);
+      fragment.getScalarOperand((inst.srsrc << 2) + 0, TypeId::UInt32);
     auto vBuffer1 =
-        fragment.getScalarOperand((inst.srsrc << 2) + 1, TypeId::UInt32);
+      fragment.getScalarOperand((inst.srsrc << 2) + 1, TypeId::UInt32);
     auto vBuffer2 =
-        fragment.getScalarOperand((inst.srsrc << 2) + 2, TypeId::UInt32);
+      fragment.getScalarOperand((inst.srsrc << 2) + 2, TypeId::UInt32);
     auto vBuffer3 =
-        fragment.getScalarOperand((inst.srsrc << 2) + 3, TypeId::UInt32);
+      fragment.getScalarOperand((inst.srsrc << 2) + 3, TypeId::UInt32);
 
     auto optVBuffer0Value = fragment.context->findUint32Value(vBuffer0.value);
     auto optVBuffer1Value = fragment.context->findUint32Value(vBuffer1.value);
@@ -2691,7 +2691,7 @@ void convertMubuf(Fragment &fragment, Mubuf inst) {
       // V# buffer value is known, read the buffer now
       std::array<std::uint32_t, 4> vBufferData = {
           *optVBuffer0Value, *optVBuffer1Value, *optVBuffer2Value,
-          *optVBuffer3Value};
+          *optVBuffer3Value };
 
       GnmVBuffer result;
       std::memcpy(&result, vBufferData.data(), sizeof(result));
@@ -2699,7 +2699,7 @@ void convertMubuf(Fragment &fragment, Mubuf inst) {
     }
 
     util::unreachable();
-  };
+    };
 
   auto getAddress = [&](GnmVBuffer *vbuffer) {
     auto &builder = fragment.builder;
@@ -2708,14 +2708,14 @@ void convertMubuf(Fragment &fragment, Mubuf inst) {
     spirv::UIntValue index;
     if (inst.idxen) {
       index = spirv::cast<spirv::UIntValue>(
-          fragment.getVectorOperand(inst.vaddr, TypeId::UInt32).value);
+        fragment.getVectorOperand(inst.vaddr, TypeId::UInt32).value);
     }
 
     // std::printf("vBuffer address = %lx\n", vbuffer->getAddress());
 
     if (vbuffer->addtid_en) {
       spirv::UIntValue threadId =
-          builder.createLoad(uint32T, fragment.context->getThreadId());
+        builder.createLoad(uint32T, fragment.context->getThreadId());
 
       if (index) {
         index = builder.createIAdd(uint32T, index, threadId);
@@ -2725,14 +2725,14 @@ void convertMubuf(Fragment &fragment, Mubuf inst) {
     }
 
     auto offset = inst.offset ? fragment.context->getUInt32(inst.offset)
-                              : spirv::UIntValue{};
+      : spirv::UIntValue{};
 
     if (inst.offen) {
       auto off = spirv::cast<spirv::UIntValue>(
-          fragment
-              .getVectorOperand(inst.vaddr + (inst.idxen ? 1 : 0),
-                                TypeId::UInt32)
-              .value);
+        fragment
+        .getVectorOperand(inst.vaddr + (inst.idxen ? 1 : 0),
+                          TypeId::UInt32)
+        .value);
 
       if (offset) {
         offset = builder.createIAdd(uint32T, off, offset);
@@ -2749,7 +2749,7 @@ void convertMubuf(Fragment &fragment, Mubuf inst) {
       }
 
       auto offset = builder.createIMul(
-          uint32T, index, fragment.context->getUInt32(vbuffer->stride));
+        uint32T, index, fragment.context->getUInt32(vbuffer->stride));
       if (address == fragment.context->getUInt32(0)) {
         return offset;
       }
@@ -2771,20 +2771,20 @@ void convertMubuf(Fragment &fragment, Mubuf inst) {
       auto offset_lsb = builder.createUMod(uint32T, offset, elementSize);
 
       auto indexMsb = builder.createIMul(
-          uint32T, index_msb, fragment.context->getUInt32(vbuffer->stride));
+        uint32T, index_msb, fragment.context->getUInt32(vbuffer->stride));
       auto offsetMsb = builder.createIMul(
-          uint32T, offset_msb,
-          fragment.context->getUInt32(vbuffer->element_size));
+        uint32T, offset_msb,
+        fragment.context->getUInt32(vbuffer->element_size));
 
       address = builder.createIAdd(
-          uint32T, address,
-          builder.createIMul(uint32T,
-                             builder.createIAdd(uint32T, indexMsb, offsetMsb),
-                             indexStride));
+        uint32T, address,
+        builder.createIMul(uint32T,
+                           builder.createIAdd(uint32T, indexMsb, offsetMsb),
+                           indexStride));
 
       address = builder.createIAdd(
-          uint32T, address,
-          builder.createIMul(uint32T, index_lsb, elementSize));
+        uint32T, address,
+        builder.createIMul(uint32T, index_lsb, elementSize));
 
       return builder.createIAdd(uint32T, address, offset_lsb);
     }
@@ -2795,10 +2795,10 @@ void convertMubuf(Fragment &fragment, Mubuf inst) {
       auto index_lsb = builder.createUMod(uint32T, index, indexStride);
 
       auto indexMsb = builder.createIMul(
-          uint32T, index_msb, fragment.context->getUInt32(vbuffer->stride));
+        uint32T, index_msb, fragment.context->getUInt32(vbuffer->stride));
 
       return builder.createIAdd(
-          uint32T, address, builder.createIMul(uint32T, indexMsb, indexStride));
+        uint32T, address, builder.createIMul(uint32T, indexMsb, indexStride));
     }
 
     if (!offset) {
@@ -2811,14 +2811,14 @@ void convertMubuf(Fragment &fragment, Mubuf inst) {
     auto offset_lsb = builder.createUMod(uint32T, offset, elementSize);
 
     auto offsetMsb =
-        builder.createIMul(uint32T, offset_msb,
-                           fragment.context->getUInt32(vbuffer->element_size));
+      builder.createIMul(uint32T, offset_msb,
+                         fragment.context->getUInt32(vbuffer->element_size));
 
     address = builder.createIAdd(
-        uint32T, address, builder.createIMul(uint32T, offsetMsb, indexStride));
+      uint32T, address, builder.createIMul(uint32T, offsetMsb, indexStride));
 
     return builder.createIAdd(uint32T, address, offset_lsb);
-  };
+    };
 
   switch (inst.op) {
   case Mubuf::Op::BUFFER_LOAD_FORMAT_X:
@@ -2826,18 +2826,18 @@ void convertMubuf(Fragment &fragment, Mubuf inst) {
   case Mubuf::Op::BUFFER_LOAD_FORMAT_XYZ:
   case Mubuf::Op::BUFFER_LOAD_FORMAT_XYZW: {
     std::uint32_t count = static_cast<int>(inst.op) -
-                          static_cast<int>(Mubuf::Op::BUFFER_LOAD_FORMAT_X) + 1;
+      static_cast<int>(Mubuf::Op::BUFFER_LOAD_FORMAT_X) + 1;
 
     auto vbuffer = getVBuffer();
     auto address = getAddress(&vbuffer);
 
     spirv::Value result[4];
     auto resultType = convertFromFormat(
-        result, count, fragment, reinterpret_cast<std::uint32_t *>(&vbuffer),
-        address, vbuffer.dfmt, vbuffer.nfmt);
+      result, count, fragment, reinterpret_cast<std::uint32_t *>(&vbuffer),
+      address, vbuffer.dfmt, vbuffer.nfmt);
 
     for (std::uint32_t i = 0; i < count; ++i) {
-      fragment.setVectorOperand(inst.vdata + i, {resultType, result[i]});
+      fragment.setVectorOperand(inst.vdata + i, { resultType, result[i] });
     }
     break;
   }
@@ -2847,8 +2847,8 @@ void convertMubuf(Fragment &fragment, Mubuf inst) {
   case Mubuf::Op::BUFFER_STORE_FORMAT_XYZ:
   case Mubuf::Op::BUFFER_STORE_FORMAT_XYZW: {
     std::uint32_t count = static_cast<int>(inst.op) -
-                          static_cast<int>(Mubuf::Op::BUFFER_STORE_FORMAT_X) +
-                          1;
+      static_cast<int>(Mubuf::Op::BUFFER_STORE_FORMAT_X) +
+      1;
 
     auto vbuffer = getVBuffer();
     auto address = getAddress(&vbuffer);
@@ -2871,36 +2871,36 @@ void convertMubuf(Fragment &fragment, Mubuf inst) {
   case Mubuf::Op::BUFFER_LOAD_DWORDX4:
   case Mubuf::Op::BUFFER_LOAD_DWORDX3: {
     std::uint32_t count = static_cast<int>(inst.op) -
-                          static_cast<int>(Mubuf::Op::BUFFER_LOAD_DWORD) + 1;
+      static_cast<int>(Mubuf::Op::BUFFER_LOAD_DWORD) + 1;
 
     auto vbuffer = getVBuffer();
     auto address = getAddress(&vbuffer);
     auto loadType = fragment.context->getType(TypeId::UInt32);
     auto uniform = fragment.context->getOrCreateStorageBuffer(
-        reinterpret_cast<std::uint32_t *>(&vbuffer), TypeId::UInt32);
+      reinterpret_cast<std::uint32_t *>(&vbuffer), TypeId::UInt32);
     uniform->accessOp |= AccessOp::Load;
 
     auto uniformPointerType = fragment.context->getPointerType(
-        spv::StorageClass::StorageBuffer, TypeId::UInt32);
+      spv::StorageClass::StorageBuffer, TypeId::UInt32);
     address =
-        fragment.builder.createUDiv(fragment.context->getUInt32Type(), address,
-                                    fragment.context->getUInt32(4));
+      fragment.builder.createUDiv(fragment.context->getUInt32Type(), address,
+                                  fragment.context->getUInt32(4));
 
     for (int i = 0; i < count; ++i) {
       auto channelOffset = address;
 
       if (i != 0) {
         channelOffset = fragment.builder.createIAdd(
-            fragment.context->getUInt32Type(), channelOffset,
-            fragment.context->getUInt32(i));
+          fragment.context->getUInt32Type(), channelOffset,
+          fragment.context->getUInt32(i));
       }
 
       auto uniformPointerValue = fragment.builder.createAccessChain(
-          uniformPointerType, uniform->variable,
-          {{fragment.context->getUInt32(0), channelOffset}});
+        uniformPointerType, uniform->variable,
+        { {fragment.context->getUInt32(0), channelOffset} });
 
       auto value = fragment.builder.createLoad(loadType, uniformPointerValue);
-      fragment.setVectorOperand(inst.vdata + i, {loadType, value});
+      fragment.setVectorOperand(inst.vdata + i, { loadType, value });
     }
     break;
   }
@@ -2915,37 +2915,37 @@ void convertMubuf(Fragment &fragment, Mubuf inst) {
   case Mubuf::Op::BUFFER_STORE_DWORDX4:
   case Mubuf::Op::BUFFER_STORE_DWORDX3: {
     std::uint32_t count = static_cast<int>(inst.op) -
-                          static_cast<int>(Mubuf::Op::BUFFER_STORE_DWORD) + 1;
+      static_cast<int>(Mubuf::Op::BUFFER_STORE_DWORD) + 1;
 
     auto vbuffer = getVBuffer();
     auto address = getAddress(&vbuffer);
     auto storeType = fragment.context->getType(TypeId::UInt32);
     auto uniform = fragment.context->getOrCreateStorageBuffer(
-        reinterpret_cast<std::uint32_t *>(&vbuffer), TypeId::UInt32);
+      reinterpret_cast<std::uint32_t *>(&vbuffer), TypeId::UInt32);
     uniform->accessOp |= AccessOp::Store;
 
     auto uniformPointerType = fragment.context->getPointerType(
-        spv::StorageClass::StorageBuffer, TypeId::UInt32);
+      spv::StorageClass::StorageBuffer, TypeId::UInt32);
     address =
-        fragment.builder.createUDiv(fragment.context->getUInt32Type(), address,
-                                    fragment.context->getUInt32(4));
+      fragment.builder.createUDiv(fragment.context->getUInt32Type(), address,
+                                  fragment.context->getUInt32(4));
 
     for (int i = 0; i < count; ++i) {
       auto channelOffset = address;
 
       if (i != 0) {
         channelOffset = fragment.builder.createIAdd(
-            fragment.context->getUInt32Type(), channelOffset,
-            fragment.context->getUInt32(i));
+          fragment.context->getUInt32Type(), channelOffset,
+          fragment.context->getUInt32(i));
       }
 
       auto uniformPointerValue = fragment.builder.createAccessChain(
-          uniformPointerType, uniform->variable,
-          {{fragment.context->getUInt32(0), channelOffset}});
+        uniformPointerType, uniform->variable,
+        { {fragment.context->getUInt32(0), channelOffset} });
 
       fragment.builder.createStore(
-          uniformPointerValue,
-          fragment.getVectorOperand(inst.vdata + i, TypeId::UInt32).value);
+        uniformPointerValue,
+        fragment.getVectorOperand(inst.vdata + i, TypeId::UInt32).value);
     }
   }
 
@@ -2964,19 +2964,19 @@ void convertMtbuf(Fragment &fragment, Mtbuf inst) {
   case Mtbuf::Op::TBUFFER_LOAD_FORMAT_XYZ:
   case Mtbuf::Op::TBUFFER_LOAD_FORMAT_XYZW: {
     std::uint32_t count = static_cast<int>(inst.op) -
-                          static_cast<int>(Mtbuf::Op::TBUFFER_LOAD_FORMAT_X) +
-                          1;
+      static_cast<int>(Mtbuf::Op::TBUFFER_LOAD_FORMAT_X) +
+      1;
 
     auto &builder = fragment.builder;
 
     auto vBuffer0 =
-        fragment.getScalarOperand((inst.srsrc << 2) + 0, TypeId::UInt32);
+      fragment.getScalarOperand((inst.srsrc << 2) + 0, TypeId::UInt32);
     auto vBuffer1 =
-        fragment.getScalarOperand((inst.srsrc << 2) + 1, TypeId::UInt32);
+      fragment.getScalarOperand((inst.srsrc << 2) + 1, TypeId::UInt32);
     auto vBuffer2 =
-        fragment.getScalarOperand((inst.srsrc << 2) + 2, TypeId::UInt32);
+      fragment.getScalarOperand((inst.srsrc << 2) + 2, TypeId::UInt32);
     auto vBuffer3 =
-        fragment.getScalarOperand((inst.srsrc << 2) + 3, TypeId::UInt32);
+      fragment.getScalarOperand((inst.srsrc << 2) + 3, TypeId::UInt32);
 
     auto optVBuffer0Value = fragment.context->findUint32Value(vBuffer0.value);
     auto optVBuffer1Value = fragment.context->findUint32Value(vBuffer1.value);
@@ -2986,12 +2986,12 @@ void convertMtbuf(Fragment &fragment, Mtbuf inst) {
     if (optVBuffer0Value && optVBuffer1Value && optVBuffer2Value &&
         optVBuffer3Value) {
       // V# buffer value is known, read the buffer now
-      std::uint32_t vBufferData[] = {*optVBuffer0Value, *optVBuffer1Value,
-                                     *optVBuffer2Value, *optVBuffer3Value};
+      std::uint32_t vBufferData[] = { *optVBuffer0Value, *optVBuffer1Value,
+                                     *optVBuffer2Value, *optVBuffer3Value };
 
       auto vbuffer = reinterpret_cast<GnmVBuffer *>(vBufferData);
       auto base = spirv::cast<spirv::UIntValue>(
-          fragment.getScalarOperand(inst.soffset, TypeId::UInt32).value);
+        fragment.getScalarOperand(inst.soffset, TypeId::UInt32).value);
 
       auto uint32T = fragment.context->getUInt32Type();
       auto uint32_0 = fragment.context->getUInt32(0);
@@ -3000,7 +3000,7 @@ void convertMtbuf(Fragment &fragment, Mtbuf inst) {
         util::unreachable("!! dfmt is invalid !!\n");
 
         for (std::uint32_t i = 0; i < count; ++i) {
-          fragment.setVectorOperand(inst.vdata + i, {uint32T, uint32_0});
+          fragment.setVectorOperand(inst.vdata + i, { uint32T, uint32_0 });
         }
 
         return;
@@ -3009,14 +3009,14 @@ void convertMtbuf(Fragment &fragment, Mtbuf inst) {
       spirv::UIntValue index;
       if (inst.idxen) {
         index = spirv::cast<spirv::UIntValue>(
-            fragment.getVectorOperand(inst.vaddr, TypeId::UInt32).value);
+          fragment.getVectorOperand(inst.vaddr, TypeId::UInt32).value);
       }
 
       // std::printf("vBuffer address = %lx\n", vbuffer->getAddress());
 
       if (vbuffer->addtid_en) {
         spirv::UIntValue threadId =
-            builder.createLoad(uint32T, fragment.context->getThreadId());
+          builder.createLoad(uint32T, fragment.context->getThreadId());
 
         if (index) {
           index = builder.createIAdd(uint32T, index, threadId);
@@ -3026,14 +3026,14 @@ void convertMtbuf(Fragment &fragment, Mtbuf inst) {
       }
 
       auto offset = inst.offset ? fragment.context->getUInt32(inst.offset)
-                                : spirv::UIntValue{};
+        : spirv::UIntValue{};
 
       if (inst.offen) {
         auto off = spirv::cast<spirv::UIntValue>(
-            fragment
-                .getVectorOperand(inst.vaddr + (inst.idxen ? 1 : 0),
-                                  TypeId::UInt32)
-                .value);
+          fragment
+          .getVectorOperand(inst.vaddr + (inst.idxen ? 1 : 0),
+                            TypeId::UInt32)
+          .value);
 
         if (offset) {
           offset = builder.createIAdd(uint32T, off, offset);
@@ -3046,7 +3046,7 @@ void convertMtbuf(Fragment &fragment, Mtbuf inst) {
       if (vbuffer->swizzle_en == 0) {
         if (vbuffer->stride != 0 && index) {
           auto offset = builder.createIMul(
-              uint32T, index, fragment.context->getUInt32(vbuffer->stride));
+            uint32T, index, fragment.context->getUInt32(vbuffer->stride));
           if (address == uint32_0) {
             address = offset;
           } else {
@@ -3064,20 +3064,20 @@ void convertMtbuf(Fragment &fragment, Mtbuf inst) {
           auto offset_lsb = builder.createUMod(uint32T, offset, elementSize);
 
           auto indexMsb = builder.createIMul(
-              uint32T, index_msb, fragment.context->getUInt32(vbuffer->stride));
+            uint32T, index_msb, fragment.context->getUInt32(vbuffer->stride));
           auto offsetMsb = builder.createIMul(
-              uint32T, offset_msb,
-              fragment.context->getUInt32(vbuffer->element_size));
+            uint32T, offset_msb,
+            fragment.context->getUInt32(vbuffer->element_size));
 
           address = builder.createIAdd(
-              uint32T, address,
-              builder.createIMul(
-                  uint32T, builder.createIAdd(uint32T, indexMsb, offsetMsb),
-                  indexStride));
+            uint32T, address,
+            builder.createIMul(
+              uint32T, builder.createIAdd(uint32T, indexMsb, offsetMsb),
+              indexStride));
 
           address = builder.createIAdd(
-              uint32T, address,
-              builder.createIMul(uint32T, index_lsb, elementSize));
+            uint32T, address,
+            builder.createIMul(uint32T, index_lsb, elementSize));
 
           address = builder.createIAdd(uint32T, address, offset_lsb);
         } else if (index) {
@@ -3086,11 +3086,11 @@ void convertMtbuf(Fragment &fragment, Mtbuf inst) {
           auto index_lsb = builder.createUMod(uint32T, index, indexStride);
 
           auto indexMsb = builder.createIMul(
-              uint32T, index_msb, fragment.context->getUInt32(vbuffer->stride));
+            uint32T, index_msb, fragment.context->getUInt32(vbuffer->stride));
 
           address = builder.createIAdd(
-              uint32T, address,
-              builder.createIMul(uint32T, indexMsb, indexStride));
+            uint32T, address,
+            builder.createIMul(uint32T, indexMsb, indexStride));
         } else if (offset) {
           auto indexStride = fragment.context->getUInt32(vbuffer->index_stride);
           auto elementSize = fragment.context->getUInt32(vbuffer->element_size);
@@ -3098,12 +3098,12 @@ void convertMtbuf(Fragment &fragment, Mtbuf inst) {
           auto offset_lsb = builder.createUMod(uint32T, offset, elementSize);
 
           auto offsetMsb = builder.createIMul(
-              uint32T, offset_msb,
-              fragment.context->getUInt32(vbuffer->element_size));
+            uint32T, offset_msb,
+            fragment.context->getUInt32(vbuffer->element_size));
 
           address = builder.createIAdd(
-              uint32T, address,
-              builder.createIMul(uint32T, offsetMsb, indexStride));
+            uint32T, address,
+            builder.createIMul(uint32T, offsetMsb, indexStride));
 
           address = builder.createIAdd(uint32T, address, offset_lsb);
         }
@@ -3114,7 +3114,7 @@ void convertMtbuf(Fragment &fragment, Mtbuf inst) {
                                           address, inst.dfmt, inst.nfmt);
 
       for (std::uint32_t i = 0; i < count; ++i) {
-        fragment.setVectorOperand(inst.vdata + i, {resultType, result[i]});
+        fragment.setVectorOperand(inst.vdata + i, { resultType, result[i] });
       }
       break;
     } else {
@@ -3127,18 +3127,18 @@ void convertMtbuf(Fragment &fragment, Mtbuf inst) {
   case Mtbuf::Op::TBUFFER_STORE_FORMAT_XYZ:
   case Mtbuf::Op::TBUFFER_STORE_FORMAT_XYZW: {
     std::uint32_t count = static_cast<int>(inst.op) -
-                          static_cast<int>(Mtbuf::Op::TBUFFER_STORE_FORMAT_X) +
-                          1;
+      static_cast<int>(Mtbuf::Op::TBUFFER_STORE_FORMAT_X) +
+      1;
     auto &builder = fragment.builder;
 
     auto vBuffer0 =
-        fragment.getScalarOperand((inst.srsrc << 2) + 0, TypeId::UInt32);
+      fragment.getScalarOperand((inst.srsrc << 2) + 0, TypeId::UInt32);
     auto vBuffer1 =
-        fragment.getScalarOperand((inst.srsrc << 2) + 1, TypeId::UInt32);
+      fragment.getScalarOperand((inst.srsrc << 2) + 1, TypeId::UInt32);
     auto vBuffer2 =
-        fragment.getScalarOperand((inst.srsrc << 2) + 2, TypeId::UInt32);
+      fragment.getScalarOperand((inst.srsrc << 2) + 2, TypeId::UInt32);
     auto vBuffer3 =
-        fragment.getScalarOperand((inst.srsrc << 2) + 3, TypeId::UInt32);
+      fragment.getScalarOperand((inst.srsrc << 2) + 3, TypeId::UInt32);
 
     auto optVBuffer0Value = fragment.context->findUint32Value(vBuffer0.value);
     auto optVBuffer1Value = fragment.context->findUint32Value(vBuffer1.value);
@@ -3148,14 +3148,14 @@ void convertMtbuf(Fragment &fragment, Mtbuf inst) {
     if (optVBuffer0Value && optVBuffer1Value && optVBuffer2Value &&
         optVBuffer3Value) {
       // V# buffer value is known, read the buffer now
-      std::uint32_t vBufferData[] = {*optVBuffer0Value, *optVBuffer1Value,
-                                     *optVBuffer2Value, *optVBuffer3Value};
+      std::uint32_t vBufferData[] = { *optVBuffer0Value, *optVBuffer1Value,
+                                     *optVBuffer2Value, *optVBuffer3Value };
 
       auto vbuffer = reinterpret_cast<GnmVBuffer *>(vBufferData);
       // std::printf("vBuffer address = %lx\n", vbuffer->getAddress());
 
       auto base = spirv::cast<spirv::UIntValue>(
-          fragment.getScalarOperand(inst.soffset, TypeId::UInt32).value);
+        fragment.getScalarOperand(inst.soffset, TypeId::UInt32).value);
 
       auto uint32T = fragment.context->getUInt32Type();
       auto uint32_0 = fragment.context->getUInt32(0);
@@ -3164,7 +3164,7 @@ void convertMtbuf(Fragment &fragment, Mtbuf inst) {
         util::unreachable("!! dfmt is invalid !!\n");
 
         for (std::uint32_t i = 0; i < count; ++i) {
-          fragment.setVectorOperand(inst.vdata + i, {uint32T, uint32_0});
+          fragment.setVectorOperand(inst.vdata + i, { uint32T, uint32_0 });
         }
 
         return;
@@ -3173,12 +3173,12 @@ void convertMtbuf(Fragment &fragment, Mtbuf inst) {
       spirv::UIntValue index;
       if (inst.idxen) {
         index = spirv::cast<spirv::UIntValue>(
-            fragment.getVectorOperand(inst.vaddr, TypeId::UInt32).value);
+          fragment.getVectorOperand(inst.vaddr, TypeId::UInt32).value);
       }
 
       if (vbuffer->addtid_en) {
         spirv::UIntValue threadId =
-            builder.createLoad(uint32T, fragment.context->getThreadId());
+          builder.createLoad(uint32T, fragment.context->getThreadId());
 
         if (index) {
           index = builder.createIAdd(uint32T, index, threadId);
@@ -3188,14 +3188,14 @@ void convertMtbuf(Fragment &fragment, Mtbuf inst) {
       }
 
       auto offset = inst.offset ? fragment.context->getUInt32(inst.offset)
-                                : spirv::UIntValue{};
+        : spirv::UIntValue{};
 
       if (inst.offen) {
         auto off = spirv::cast<spirv::UIntValue>(
-            fragment
-                .getVectorOperand(inst.vaddr + (inst.idxen ? 1 : 0),
-                                  TypeId::UInt32)
-                .value);
+          fragment
+          .getVectorOperand(inst.vaddr + (inst.idxen ? 1 : 0),
+                            TypeId::UInt32)
+          .value);
 
         if (offset) {
           offset = builder.createIAdd(uint32T, off, offset);
@@ -3208,7 +3208,7 @@ void convertMtbuf(Fragment &fragment, Mtbuf inst) {
       if (vbuffer->swizzle_en == 0) {
         if (vbuffer->stride != 0 && index) {
           auto offset = builder.createIMul(
-              uint32T, index, fragment.context->getUInt32(vbuffer->stride));
+            uint32T, index, fragment.context->getUInt32(vbuffer->stride));
           if (address == uint32_0) {
             address = offset;
           } else {
@@ -3226,20 +3226,20 @@ void convertMtbuf(Fragment &fragment, Mtbuf inst) {
           auto offset_lsb = builder.createUMod(uint32T, offset, elementSize);
 
           auto indexMsb = builder.createIMul(
-              uint32T, index_msb, fragment.context->getUInt32(vbuffer->stride));
+            uint32T, index_msb, fragment.context->getUInt32(vbuffer->stride));
           auto offsetMsb = builder.createIMul(
-              uint32T, offset_msb,
-              fragment.context->getUInt32(vbuffer->element_size));
+            uint32T, offset_msb,
+            fragment.context->getUInt32(vbuffer->element_size));
 
           address = builder.createIAdd(
-              uint32T, address,
-              builder.createIMul(
-                  uint32T, builder.createIAdd(uint32T, indexMsb, offsetMsb),
-                  indexStride));
+            uint32T, address,
+            builder.createIMul(
+              uint32T, builder.createIAdd(uint32T, indexMsb, offsetMsb),
+              indexStride));
 
           address = builder.createIAdd(
-              uint32T, address,
-              builder.createIMul(uint32T, index_lsb, elementSize));
+            uint32T, address,
+            builder.createIMul(uint32T, index_lsb, elementSize));
 
           address = builder.createIAdd(uint32T, address, offset_lsb);
         } else if (index) {
@@ -3248,11 +3248,11 @@ void convertMtbuf(Fragment &fragment, Mtbuf inst) {
           auto index_lsb = builder.createUMod(uint32T, index, indexStride);
 
           auto indexMsb = builder.createIMul(
-              uint32T, index_msb, fragment.context->getUInt32(vbuffer->stride));
+            uint32T, index_msb, fragment.context->getUInt32(vbuffer->stride));
 
           address = builder.createIAdd(
-              uint32T, address,
-              builder.createIMul(uint32T, indexMsb, indexStride));
+            uint32T, address,
+            builder.createIMul(uint32T, indexMsb, indexStride));
         } else if (offset) {
           auto indexStride = fragment.context->getUInt32(vbuffer->index_stride);
           auto elementSize = fragment.context->getUInt32(vbuffer->element_size);
@@ -3260,12 +3260,12 @@ void convertMtbuf(Fragment &fragment, Mtbuf inst) {
           auto offset_lsb = builder.createUMod(uint32T, offset, elementSize);
 
           auto offsetMsb = builder.createIMul(
-              uint32T, offset_msb,
-              fragment.context->getUInt32(vbuffer->element_size));
+            uint32T, offset_msb,
+            fragment.context->getUInt32(vbuffer->element_size));
 
           address = builder.createIAdd(
-              uint32T, address,
-              builder.createIMul(uint32T, offsetMsb, indexStride));
+            uint32T, address,
+            builder.createIMul(uint32T, offsetMsb, indexStride));
 
           address = builder.createIAdd(uint32T, address, offset_lsb);
         }
@@ -3298,12 +3298,12 @@ void convertMimg(Fragment &fragment, Mimg inst) {
       auto uint32x2T = fragment.context->getUint32x2Type();
       auto lod = fragment.getScalarOperand(inst.vaddr, TypeId::UInt32);
       auto sizeResult =
-          fragment.builder.createImageQuerySizeLod(uint32x2T, image, lod.value);
+        fragment.builder.createImageQuerySizeLod(uint32x2T, image, lod.value);
 
       values[0] =
-          fragment.builder.createCompositeExtract(uint32T, sizeResult, {{0}});
+        fragment.builder.createCompositeExtract(uint32T, sizeResult, { {0} });
       values[1] =
-          fragment.builder.createCompositeExtract(uint32T, sizeResult, {{1}});
+        fragment.builder.createCompositeExtract(uint32T, sizeResult, { {1} });
       values[2] = fragment.context->getUInt32(1);
     }
 
@@ -3314,7 +3314,7 @@ void convertMimg(Fragment &fragment, Mimg inst) {
 
     for (std::size_t dstOffset = 0, i = 0; i < 4; ++i) {
       if (inst.dmask & (1 << i)) {
-        fragment.setVectorOperand(inst.vdata + dstOffset++, {uint32T, values[i]});
+        fragment.setVectorOperand(inst.vdata + dstOffset++, { uint32T, values[i] });
       }
     }
     break;
@@ -3324,26 +3324,26 @@ void convertMimg(Fragment &fragment, Mimg inst) {
     auto sampler = fragment.createSampler(RegisterId::Raw(inst.ssamp << 2));
     auto coord0 = fragment.getVectorOperand(inst.vaddr, TypeId::Float32).value;
     auto coord1 =
-        fragment.getVectorOperand(inst.vaddr + 1, TypeId::Float32).value;
+      fragment.getVectorOperand(inst.vaddr + 1, TypeId::Float32).value;
     auto coord2 =
-        fragment.getVectorOperand(inst.vaddr + 2, TypeId::Float32).value;
+      fragment.getVectorOperand(inst.vaddr + 2, TypeId::Float32).value;
     auto coords = fragment.builder.createCompositeConstruct(
-        fragment.context->getFloat32x3Type(),
-        {{coord0, coord1, coord2}}); // TODO
+      fragment.context->getFloat32x3Type(),
+      { {coord0, coord1, coord2} }); // TODO
 
     auto sampledImage2dT = fragment.context->getSampledImage2DType();
     auto float4T = fragment.context->getFloat32x4Type();
     auto floatT = fragment.context->getFloat32Type();
     auto sampledImage =
-        fragment.builder.createSampledImage(sampledImage2dT, image, sampler);
+      fragment.builder.createSampledImage(sampledImage2dT, image, sampler);
     auto value = fragment.builder.createImageSampleImplicitLod(
-        float4T, sampledImage, coords);
+      float4T, sampledImage, coords);
 
     for (std::uint32_t dstOffset = 0, i = 0; i < 4; ++i) {
       if (inst.dmask & (1 << i)) {
         fragment.setVectorOperand(
-            inst.vdata + dstOffset++, {floatT, fragment.builder.createCompositeExtract(
-                                         floatT, value, {{i}})});
+          inst.vdata + dstOffset++, { floatT, fragment.builder.createCompositeExtract(
+                                       floatT, value, {{i}}) });
       }
     }
     break;
@@ -3354,7 +3354,7 @@ void convertMimg(Fragment &fragment, Mimg inst) {
     for (std::uint32_t dstOffset = 0, i = 0; i < 4; ++i) {
       if (inst.dmask & (1 << i)) {
         fragment.setVectorOperand(
-            inst.vdata + dstOffset++, {intT, fragment.context->getUInt32(0)});
+          inst.vdata + dstOffset++, { intT, fragment.context->getUInt32(0) });
       }
     }
     break;
@@ -3392,9 +3392,9 @@ void convertVintrp(Fragment &fragment, Vintrp inst) {
     auto attr = fragment.getAttrOperand(inst.attr, TypeId::Float32x4);
     auto channelType = fragment.context->getType(TypeId::Float32);
     auto attrChan = fragment.builder.createCompositeExtract(
-        channelType, attr.value,
-        std::array{static_cast<std::uint32_t>(inst.attrChan)});
-    fragment.setVectorOperand(inst.vdst, {channelType, attrChan});
+      channelType, attr.value,
+      std::array{ static_cast<std::uint32_t>(inst.attrChan) });
+    fragment.setVectorOperand(inst.vdst, { channelType, attrChan });
     break;
   }
 
@@ -3426,17 +3426,17 @@ void convertExp(Fragment &fragment, Exp inst) {
     auto zwUint = fragment.getVectorOperand(inst.vsrc1, TypeId::UInt32).value;
 
     auto xy = fragment.builder.createExtInst(
-        float2T, glslStd450, GLSLstd450UnpackHalf2x16, std::array{xyUint});
+      float2T, glslStd450, GLSLstd450UnpackHalf2x16, std::array{ xyUint });
     auto zw = fragment.builder.createExtInst(
-        float2T, glslStd450, GLSLstd450UnpackHalf2x16, std::array{zwUint});
+      float2T, glslStd450, GLSLstd450UnpackHalf2x16, std::array{ zwUint });
     exports[0] = fragment.builder.createCompositeExtract(
-        floatT, xy, std::array{static_cast<std::uint32_t>(0)});
+      floatT, xy, std::array{ static_cast<std::uint32_t>(0) });
     exports[1] = fragment.builder.createCompositeExtract(
-        floatT, xy, std::array{static_cast<std::uint32_t>(1)});
+      floatT, xy, std::array{ static_cast<std::uint32_t>(1) });
     exports[2] = fragment.builder.createCompositeExtract(
-        floatT, zw, std::array{static_cast<std::uint32_t>(0)});
+      floatT, zw, std::array{ static_cast<std::uint32_t>(0) });
     exports[3] = fragment.builder.createCompositeExtract(
-        floatT, zw, std::array{static_cast<std::uint32_t>(1)});
+      floatT, zw, std::array{ static_cast<std::uint32_t>(1) });
     // value = fragment.builder.createCompositeConstruct(type, std::array{x, y,
     // z, w});
   } else {
@@ -3457,22 +3457,22 @@ void convertExp(Fragment &fragment, Exp inst) {
 
   auto resultType = fragment.context->getFloat32x4Type();
   auto floatType = fragment.context->getFloat32Type();
-/*
-  if (inst.en != 0xf) {
-    auto prevValue = fragment.getExportTarget(inst.target, TypeId::Float32x4);
-    if (prevValue) {
-      for (std::uint32_t i = 0; i < 4; ++i) {
-        if (~inst.en & (1 << i)) {
-          exports[i] = fragment.builder.createCompositeExtract(
-              floatType, prevValue.value, {{i}});
+  /*
+    if (inst.en != 0xf) {
+      auto prevValue = fragment.getExportTarget(inst.target, TypeId::Float32x4);
+      if (prevValue) {
+        for (std::uint32_t i = 0; i < 4; ++i) {
+          if (~inst.en & (1 << i)) {
+            exports[i] = fragment.builder.createCompositeExtract(
+                floatType, prevValue.value, {{i}});
+          }
         }
       }
     }
-  }
-*/
+  */
 
   auto value = fragment.builder.createCompositeConstruct(resultType, exports);
-  fragment.setExportTarget(inst.target, {resultType, value});
+  fragment.setExportTarget(inst.target, { resultType, value });
 }
 
 void convertVop1(Fragment &fragment, Vop1 inst) {
@@ -3480,91 +3480,91 @@ void convertVop1(Fragment &fragment, Vop1 inst) {
   switch (inst.op) {
   case Vop1::Op::V_MOV_B32:
     fragment.setVectorOperand(
-        inst.vdst, fragment.getScalarOperand(inst.src0, TypeId::UInt32,
-                                             OperandGetFlags::PreserveType));
+      inst.vdst, fragment.getScalarOperand(inst.src0, TypeId::UInt32,
+                                           OperandGetFlags::PreserveType));
     break;
 
   case Vop1::Op::V_RCP_F32: {
     auto src = spirv::cast<spirv::FloatValue>(
-        fragment.getScalarOperand(inst.src0, TypeId::Float32).value);
+      fragment.getScalarOperand(inst.src0, TypeId::Float32).value);
     auto floatT = fragment.context->getFloat32Type();
     auto float1 = fragment.context->getFloat32(1);
     auto result = fragment.builder.createFDiv(floatT, float1, src);
 
-    fragment.setVectorOperand(inst.vdst, {floatT, result});
+    fragment.setVectorOperand(inst.vdst, { floatT, result });
     break;
   }
 
   case Vop1::Op::V_RSQ_F32: {
     auto src = spirv::cast<spirv::FloatValue>(
-        fragment.getScalarOperand(inst.src0, TypeId::Float32).value);
+      fragment.getScalarOperand(inst.src0, TypeId::Float32).value);
     auto floatT = fragment.context->getFloat32Type();
     auto float1 = fragment.context->getFloat32(1);
 
     auto glslStd450 = fragment.context->getGlslStd450();
     auto result = fragment.builder.createExtInst(
-        floatT, glslStd450, GLSLstd450InverseSqrt, {{src}});
+      floatT, glslStd450, GLSLstd450InverseSqrt, { {src} });
 
-    fragment.setVectorOperand(inst.vdst, {floatT, result});
+    fragment.setVectorOperand(inst.vdst, { floatT, result });
     break;
   }
 
   case Vop1::Op::V_SQRT_F32: {
     auto src = spirv::cast<spirv::FloatValue>(
-        fragment.getScalarOperand(inst.src0, TypeId::Float32).value);
+      fragment.getScalarOperand(inst.src0, TypeId::Float32).value);
     auto floatT = fragment.context->getFloat32Type();
 
     auto glslStd450 = fragment.context->getGlslStd450();
     auto result = fragment.builder.createExtInst(floatT, glslStd450,
-                                                 GLSLstd450Sqrt, {{src}});
+                                                 GLSLstd450Sqrt, { {src} });
 
-    fragment.setVectorOperand(inst.vdst, {floatT, result});
+    fragment.setVectorOperand(inst.vdst, { floatT, result });
     break;
   }
 
   case Vop1::Op::V_EXP_F32: {
     auto src = spirv::cast<spirv::FloatValue>(
-        fragment.getScalarOperand(inst.src0, TypeId::Float32).value);
+      fragment.getScalarOperand(inst.src0, TypeId::Float32).value);
     auto floatT = fragment.context->getFloat32Type();
 
     auto glslStd450 = fragment.context->getGlslStd450();
     auto result = fragment.builder.createExtInst(floatT, glslStd450,
-                                                 GLSLstd450Exp2, {{src}});
+                                                 GLSLstd450Exp2, { {src} });
 
-    fragment.setVectorOperand(inst.vdst, {floatT, result});
+    fragment.setVectorOperand(inst.vdst, { floatT, result });
     break;
   }
 
 
   case Vop1::Op::V_FRACT_F32: {
     auto src = spirv::cast<spirv::FloatValue>(
-        fragment.getScalarOperand(inst.src0, TypeId::Float32).value);
+      fragment.getScalarOperand(inst.src0, TypeId::Float32).value);
     auto floatT = fragment.context->getFloat32Type();
 
     auto glslStd450 = fragment.context->getGlslStd450();
     auto result = fragment.builder.createExtInst(floatT, glslStd450,
-                                                 GLSLstd450Fract, {{src}});
+                                                 GLSLstd450Fract, { {src} });
 
-    fragment.setVectorOperand(inst.vdst, {floatT, result});
+    fragment.setVectorOperand(inst.vdst, { floatT, result });
     break;
   }
 
   case Vop1::Op::V_CVT_I32_F32: {
     auto src = spirv::cast<spirv::SIntValue>(
-        fragment.getScalarOperand(inst.src0, TypeId::Float32).value);
+      fragment.getScalarOperand(inst.src0, TypeId::Float32).value);
     auto resultType = fragment.context->getType(TypeId::SInt32);
     auto result = fragment.builder.createConvertFToS(resultType, src);
 
-    fragment.setVectorOperand(inst.vdst, {resultType, result});
+    fragment.setVectorOperand(inst.vdst, { resultType, result });
     break;
   }
   case Vop1::Op::V_CVT_F32_I32: {
     auto src = spirv::cast<spirv::SIntValue>(
-        fragment.getScalarOperand(inst.src0, TypeId::SInt32).value);
+      fragment.getScalarOperand(inst.src0, TypeId::SInt32).value);
     auto resultType = fragment.context->getType(TypeId::Float32);
     auto result = fragment.builder.createConvertSToF(resultType, src);
 
-    fragment.setVectorOperand(inst.vdst, {resultType, result});
+    fragment.setVectorOperand(inst.vdst, { resultType, result });
     break;
   }
 
@@ -3573,52 +3573,52 @@ void convertVop1(Fragment &fragment, Vop1 inst) {
     auto resultType = fragment.context->getType(TypeId::UInt32);
     auto result = fragment.builder.createConvertFToU(resultType, src);
 
-    fragment.setVectorOperand(inst.vdst, {resultType, result});
+    fragment.setVectorOperand(inst.vdst, { resultType, result });
     break;
   }
   case Vop1::Op::V_CVT_F32_U32: {
     auto src = fragment.getScalarOperand(inst.src0, TypeId::UInt32).value;
     auto resultType = fragment.context->getFloat32Type();
     auto result = fragment.builder.createConvertUToF(
-        resultType, spirv::cast<spirv::UIntValue>(src));
+      resultType, spirv::cast<spirv::UIntValue>(src));
 
-    fragment.setVectorOperand(inst.vdst, {resultType, result});
+    fragment.setVectorOperand(inst.vdst, { resultType, result });
     break;
   }
   case Vop1::Op::V_FLOOR_F32: {
     auto src = spirv::cast<spirv::FloatValue>(
-        fragment.getScalarOperand(inst.src0, TypeId::Float32).value);
+      fragment.getScalarOperand(inst.src0, TypeId::Float32).value);
     auto floatT = fragment.context->getFloat32Type();
 
     auto glslStd450 = fragment.context->getGlslStd450();
     auto result = fragment.builder.createExtInst(floatT, glslStd450,
-                                                 GLSLstd450Floor, {{src}});
+                                                 GLSLstd450Floor, { {src} });
 
-    fragment.setVectorOperand(inst.vdst, {floatT, result});
+    fragment.setVectorOperand(inst.vdst, { floatT, result });
     break;
   }
   case Vop1::Op::V_SIN_F32: {
     auto src = spirv::cast<spirv::FloatValue>(
-        fragment.getScalarOperand(inst.src0, TypeId::Float32).value);
+      fragment.getScalarOperand(inst.src0, TypeId::Float32).value);
     auto floatT = fragment.context->getFloat32Type();
 
     auto glslStd450 = fragment.context->getGlslStd450();
     auto result = fragment.builder.createExtInst(floatT, glslStd450,
-                                                 GLSLstd450Sin, {{src}});
+                                                 GLSLstd450Sin, { {src} });
 
-    fragment.setVectorOperand(inst.vdst, {floatT, result});
+    fragment.setVectorOperand(inst.vdst, { floatT, result });
     break;
   }
   case Vop1::Op::V_COS_F32: {
     auto src = spirv::cast<spirv::FloatValue>(
-        fragment.getScalarOperand(inst.src0, TypeId::Float32).value);
+      fragment.getScalarOperand(inst.src0, TypeId::Float32).value);
     auto floatT = fragment.context->getFloat32Type();
 
     auto glslStd450 = fragment.context->getGlslStd450();
     auto result = fragment.builder.createExtInst(floatT, glslStd450,
-                                                 GLSLstd450Cos, {{src}});
+                                                 GLSLstd450Cos, { {src} });
 
-    fragment.setVectorOperand(inst.vdst, {floatT, result});
+    fragment.setVectorOperand(inst.vdst, { floatT, result });
     break;
   }
 
@@ -3637,7 +3637,7 @@ void convertVopc(Fragment &fragment, Vopc inst) {
 
     auto result = doCmpOp(fragment, type, src0, src1, kind, flags);
     fragment.setVcc(result);
-  };
+    };
 
   switch (inst.op) {
   case Vopc::Op::V_CMP_F_F32:
@@ -4048,8 +4048,8 @@ void convertVopc(Fragment &fragment, Vopc inst) {
   case Vopc::Op::V_CMP_T_I32:
     cmpOp(TypeId::SInt32, CmpKind::T);
     break;
-  // case Vopc::Op::V_CMP_CLASS_F32: cmpOp(TypeId::Float32, CmpKind::CLASS);
-  // break;
+    // case Vopc::Op::V_CMP_CLASS_F32: cmpOp(TypeId::Float32, CmpKind::CLASS);
+    // break;
   case Vopc::Op::V_CMP_LT_I16:
     cmpOp(TypeId::SInt16, CmpKind::LT);
     break;
@@ -4068,8 +4068,8 @@ void convertVopc(Fragment &fragment, Vopc inst) {
   case Vopc::Op::V_CMP_GE_I16:
     cmpOp(TypeId::SInt16, CmpKind::GE);
     break;
-  // case Vopc::Op::V_CMP_CLASS_F16: cmpOp(TypeId::Float16, CmpKind::CLASS);
-  // break;
+    // case Vopc::Op::V_CMP_CLASS_F16: cmpOp(TypeId::Float16, CmpKind::CLASS);
+    // break;
   case Vopc::Op::V_CMPX_F_I32:
     cmpOp(TypeId::SInt32, CmpKind::F, CmpFlags::X);
     break;
@@ -4094,8 +4094,8 @@ void convertVopc(Fragment &fragment, Vopc inst) {
   case Vopc::Op::V_CMPX_T_I32:
     cmpOp(TypeId::SInt32, CmpKind::T, CmpFlags::X);
     break;
-  // case Vopc::Op::V_CMPX_CLASS_F32: cmpOp(TypeId::Float32, CmpKind::CLASS,
-  // CmpFlags::X); break;
+    // case Vopc::Op::V_CMPX_CLASS_F32: cmpOp(TypeId::Float32, CmpKind::CLASS,
+    // CmpFlags::X); break;
   case Vopc::Op::V_CMPX_LT_I16:
     cmpOp(TypeId::SInt16, CmpKind::LT, CmpFlags::X);
     break;
@@ -4114,8 +4114,8 @@ void convertVopc(Fragment &fragment, Vopc inst) {
   case Vopc::Op::V_CMPX_GE_I16:
     cmpOp(TypeId::SInt16, CmpKind::GE, CmpFlags::X);
     break;
-  // case Vopc::Op::V_CMPX_CLASS_F16: cmpOp(TypeId::Float16, CmpKind::CLASS,
-  // CmpFlags::X); break;
+    // case Vopc::Op::V_CMPX_CLASS_F16: cmpOp(TypeId::Float16, CmpKind::CLASS,
+    // CmpFlags::X); break;
   case Vopc::Op::V_CMP_F_I64:
     cmpOp(TypeId::SInt64, CmpKind::F);
     break;
@@ -4140,8 +4140,8 @@ void convertVopc(Fragment &fragment, Vopc inst) {
   case Vopc::Op::V_CMP_T_I64:
     cmpOp(TypeId::SInt64, CmpKind::T);
     break;
-  // case Vopc::Op::V_CMP_CLASS_F64: cmpOp(TypeId::Float64, CmpKind::CLASS);
-  // break;
+    // case Vopc::Op::V_CMP_CLASS_F64: cmpOp(TypeId::Float64, CmpKind::CLASS);
+    // break;
   case Vopc::Op::V_CMP_LT_U16:
     cmpOp(TypeId::UInt16, CmpKind::LT);
     break;
@@ -4184,8 +4184,8 @@ void convertVopc(Fragment &fragment, Vopc inst) {
   case Vopc::Op::V_CMPX_T_I64:
     cmpOp(TypeId::SInt64, CmpKind::T, CmpFlags::X);
     break;
-  // case Vopc::Op::V_CMPX_CLASS_F64: cmpOp(TypeId::Float64, CmpKind::CLASS,
-  // CmpFlags::X); break;
+    // case Vopc::Op::V_CMPX_CLASS_F64: cmpOp(TypeId::Float64, CmpKind::CLASS,
+    // CmpFlags::X); break;
   case Vopc::Op::V_CMPX_LT_U16:
     cmpOp(TypeId::UInt16, CmpKind::LT, CmpFlags::X);
     break;
@@ -4408,15 +4408,15 @@ void convertSop1(Fragment &fragment, Sop1 inst) {
   switch (inst.op) {
   case Sop1::Op::S_MOV_B32:
     fragment.setScalarOperand(
-        inst.sdst, fragment.getScalarOperand(inst.ssrc0, TypeId::UInt32));
+      inst.sdst, fragment.getScalarOperand(inst.ssrc0, TypeId::UInt32));
     break;
 
   case Sop1::Op::S_MOV_B64:
     fragment.setScalarOperand(
-        inst.sdst, fragment.getScalarOperand(inst.ssrc0, TypeId::UInt32));
+      inst.sdst, fragment.getScalarOperand(inst.ssrc0, TypeId::UInt32));
     fragment.setScalarOperand(
-        inst.sdst + 1,
-        fragment.getScalarOperand(inst.ssrc0 + 1, TypeId::UInt32));
+      inst.sdst + 1,
+      fragment.getScalarOperand(inst.ssrc0 + 1, TypeId::UInt32));
     break;
 
   case Sop1::Op::S_WQM_B32: {
@@ -4435,21 +4435,21 @@ void convertSop1(Fragment &fragment, Sop1 inst) {
     auto srcHi = fragment.getScalarOperand(inst.ssrc0 + 1, TypeId::UInt32);
 
     fragment.setOperand(
-        RegisterId::ExecLo,
-        {srcLo.type, fragment.builder.createBitwiseAnd(srcLo.type, srcLo.value,
-                                                       execLo.value)});
+      RegisterId::ExecLo,
+      { srcLo.type, fragment.builder.createBitwiseAnd(srcLo.type, srcLo.value,
+                                                     execLo.value) });
     fragment.setOperand(
-        RegisterId::ExecHi,
-        {srcHi.type, fragment.builder.createBitwiseAnd(srcHi.type, srcHi.value,
-                                                       execHi.value)});
+      RegisterId::ExecHi,
+      { srcHi.type, fragment.builder.createBitwiseAnd(srcHi.type, srcHi.value,
+                                                     execHi.value) });
     auto uint32_0 = fragment.context->getUInt32(0);
     auto boolT = fragment.context->getBoolType();
     auto loIsNotZero =
-        fragment.builder.createINotEqual(boolT, execLo.value, uint32_0);
+      fragment.builder.createINotEqual(boolT, execLo.value, uint32_0);
     auto hiIsNotZero =
-        fragment.builder.createINotEqual(boolT, execHi.value, uint32_0);
-    fragment.setScc({boolT, fragment.builder.createLogicalAnd(
-                                boolT, loIsNotZero, hiIsNotZero)});
+      fragment.builder.createINotEqual(boolT, execHi.value, uint32_0);
+    fragment.setScc({ boolT, fragment.builder.createLogicalAnd(
+                                boolT, loIsNotZero, hiIsNotZero) });
     fragment.setScalarOperand(inst.sdst, execLo);
     fragment.setScalarOperand(inst.sdst + 1, execHi);
     break;
@@ -4467,7 +4467,7 @@ void convertSop1(Fragment &fragment, Sop1 inst) {
       }
 
       fragment.jumpAddress =
-          *ssrc0OptValue | (static_cast<std::uint64_t>(*ssrc1OptValue) << 32);
+        *ssrc0OptValue | (static_cast<std::uint64_t>(*ssrc1OptValue) << 32);
     } else {
       util::unreachable();
     }
@@ -4485,14 +4485,14 @@ void convertSop1(Fragment &fragment, Sop1 inst) {
       }
 
       auto pc = fragment.registers->pc;
-      fragment.setScalarOperand(inst.sdst, {fragment.context->getUInt32Type(),
-                                            fragment.context->getUInt32(pc)});
+      fragment.setScalarOperand(inst.sdst, { fragment.context->getUInt32Type(),
+                                            fragment.context->getUInt32(pc) });
       fragment.setScalarOperand(inst.sdst + 1,
-                                {fragment.context->getUInt32Type(),
-                                 fragment.context->getUInt32(pc >> 32)});
+                                { fragment.context->getUInt32Type(),
+                                 fragment.context->getUInt32(pc >> 32) });
 
       fragment.jumpAddress =
-          *ssrc0OptValue | (static_cast<std::uint64_t>(*ssrc1OptValue) << 32);
+        *ssrc0OptValue | (static_cast<std::uint64_t>(*ssrc1OptValue) << 32);
     } else {
       inst.dump();
       util::unreachable();
@@ -4515,7 +4515,7 @@ void convertSopc(Fragment &fragment, Sopc inst) {
 
     auto result = doCmpOp(fragment, type, src0, src1, kind, CmpFlags::None);
     fragment.setScc(result);
-  };
+    };
 
   switch (inst.op) {
   case Sopc::Op::S_CMP_EQ_I32:
@@ -4557,78 +4557,78 @@ void convertSopc(Fragment &fragment, Sopc inst) {
 
   case Sopc::Op::S_BITCMP0_B32: {
     auto src0 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.ssrc0, TypeId::UInt32).value);
+      fragment.getScalarOperand(inst.ssrc0, TypeId::UInt32).value);
     auto src1 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.ssrc1, TypeId::UInt32).value);
+      fragment.getScalarOperand(inst.ssrc1, TypeId::UInt32).value);
     auto operandT = fragment.context->getUInt32Type();
 
     src1 = spirv::cast<spirv::UIntValue>(fragment.builder.createBitwiseAnd(
-        operandT, src1, fragment.context->getUInt32(0x1f)));
+      operandT, src1, fragment.context->getUInt32(0x1f)));
     auto bit = fragment.builder.createBitwiseAnd(
-        operandT,
-        fragment.builder.createShiftRightLogical(operandT, src0, src1),
-        fragment.context->getUInt32(1));
+      operandT,
+      fragment.builder.createShiftRightLogical(operandT, src0, src1),
+      fragment.context->getUInt32(1));
 
     auto boolT = fragment.context->getBoolType();
-    fragment.setScc({boolT, fragment.builder.createIEqual(
-                                boolT, bit, fragment.context->getUInt32(0))});
+    fragment.setScc({ boolT, fragment.builder.createIEqual(
+                                boolT, bit, fragment.context->getUInt32(0)) });
     break;
   }
   case Sopc::Op::S_BITCMP1_B32: {
     auto src0 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.ssrc0, TypeId::UInt32).value);
+      fragment.getScalarOperand(inst.ssrc0, TypeId::UInt32).value);
     auto src1 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.ssrc1, TypeId::UInt32).value);
+      fragment.getScalarOperand(inst.ssrc1, TypeId::UInt32).value);
     auto operandT = fragment.context->getUInt32Type();
 
     src1 = spirv::cast<spirv::UIntValue>(fragment.builder.createBitwiseAnd(
-        operandT, src1, fragment.context->getUInt32(0x1f)));
+      operandT, src1, fragment.context->getUInt32(0x1f)));
     auto bit = fragment.builder.createBitwiseAnd(
-        operandT,
-        fragment.builder.createShiftRightLogical(operandT, src0, src1),
-        fragment.context->getUInt32(1));
+      operandT,
+      fragment.builder.createShiftRightLogical(operandT, src0, src1),
+      fragment.context->getUInt32(1));
 
     auto boolT = fragment.context->getBoolType();
-    fragment.setScc({boolT, fragment.builder.createIEqual(
-                                boolT, bit, fragment.context->getUInt32(1))});
+    fragment.setScc({ boolT, fragment.builder.createIEqual(
+                                boolT, bit, fragment.context->getUInt32(1)) });
     break;
   }
   case Sopc::Op::S_BITCMP0_B64: {
     auto src0 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.ssrc0, TypeId::UInt64).value);
+      fragment.getScalarOperand(inst.ssrc0, TypeId::UInt64).value);
     auto src1 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.ssrc1, TypeId::UInt32).value);
+      fragment.getScalarOperand(inst.ssrc1, TypeId::UInt32).value);
     auto operandT = fragment.context->getUInt64Type();
 
     src1 = spirv::cast<spirv::UIntValue>(fragment.builder.createBitwiseAnd(
-        operandT, src1, fragment.context->getUInt32(0x3f)));
+      operandT, src1, fragment.context->getUInt32(0x3f)));
     auto bit = fragment.builder.createBitwiseAnd(
-        operandT,
-        fragment.builder.createShiftRightLogical(operandT, src0, src1),
-        fragment.context->getUInt64(1));
+      operandT,
+      fragment.builder.createShiftRightLogical(operandT, src0, src1),
+      fragment.context->getUInt64(1));
 
     auto boolT = fragment.context->getBoolType();
-    fragment.setScc({boolT, fragment.builder.createIEqual(
-                                boolT, bit, fragment.context->getUInt64(0))});
+    fragment.setScc({ boolT, fragment.builder.createIEqual(
+                                boolT, bit, fragment.context->getUInt64(0)) });
     break;
   }
   case Sopc::Op::S_BITCMP1_B64: {
     auto src0 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.ssrc0, TypeId::UInt64).value);
+      fragment.getScalarOperand(inst.ssrc0, TypeId::UInt64).value);
     auto src1 = spirv::cast<spirv::UIntValue>(
-        fragment.getScalarOperand(inst.ssrc1, TypeId::UInt32).value);
+      fragment.getScalarOperand(inst.ssrc1, TypeId::UInt32).value);
     auto operandT = fragment.context->getUInt64Type();
 
     src1 = spirv::cast<spirv::UIntValue>(fragment.builder.createBitwiseAnd(
-        operandT, src1, fragment.context->getUInt32(0x3f)));
+      operandT, src1, fragment.context->getUInt32(0x3f)));
     auto bit = fragment.builder.createBitwiseAnd(
-        operandT,
-        fragment.builder.createShiftRightLogical(operandT, src0, src1),
-        fragment.context->getUInt64(1));
+      operandT,
+      fragment.builder.createShiftRightLogical(operandT, src0, src1),
+      fragment.context->getUInt64(1));
 
     auto boolT = fragment.context->getBoolType();
-    fragment.setScc({boolT, fragment.builder.createIEqual(
-                                boolT, bit, fragment.context->getUInt64(1))});
+    fragment.setScc({ boolT, fragment.builder.createIEqual(
+                                boolT, bit, fragment.context->getUInt64(1)) });
     break;
   }
   default:
@@ -4655,7 +4655,7 @@ void convertSopp(Fragment &fragment, Sopp inst) {
         fragment.builder.createBranchConditional(condition,
        ifTrueTarget->builder.id, ifFalseTarget->entryBlockId);
     */
-  };
+    };
 
   switch (inst.op) {
   case Sopp::Op::S_WAITCNT:
@@ -4676,7 +4676,7 @@ void convertSopp(Fragment &fragment, Sopp inst) {
 
   case Sopp::Op::S_CBRANCH_SCC0: {
     createCondBranch(fragment.builder.createLogicalNot(
-        fragment.context->getBoolType(), fragment.getScc()));
+      fragment.context->getBoolType(), fragment.getScc()));
     break;
   }
 
@@ -4687,51 +4687,51 @@ void convertSopp(Fragment &fragment, Sopp inst) {
 
   case Sopp::Op::S_CBRANCH_VCCZ: {
     auto loIsZero = fragment.builder.createIEqual(
-        fragment.context->getBoolType(), fragment.getVccLo().value,
-        fragment.context->getUInt32(0));
+      fragment.context->getBoolType(), fragment.getVccLo().value,
+      fragment.context->getUInt32(0));
     auto hiIsZero = fragment.builder.createIEqual(
-        fragment.context->getBoolType(), fragment.getVccHi().value,
-        fragment.context->getUInt32(0));
+      fragment.context->getBoolType(), fragment.getVccHi().value,
+      fragment.context->getUInt32(0));
     createCondBranch(fragment.builder.createLogicalAnd(
-        fragment.context->getBoolType(), loIsZero, hiIsZero));
+      fragment.context->getBoolType(), loIsZero, hiIsZero));
     break;
   }
 
   case Sopp::Op::S_CBRANCH_VCCNZ: {
     auto loIsNotZero = fragment.builder.createINotEqual(
-        fragment.context->getBoolType(), fragment.getVccLo().value,
-        fragment.context->getUInt32(0));
+      fragment.context->getBoolType(), fragment.getVccLo().value,
+      fragment.context->getUInt32(0));
     auto hiIsNotZero = fragment.builder.createINotEqual(
-        fragment.context->getBoolType(), fragment.getVccHi().value,
-        fragment.context->getUInt32(0));
+      fragment.context->getBoolType(), fragment.getVccHi().value,
+      fragment.context->getUInt32(0));
 
     createCondBranch(fragment.builder.createLogicalOr(
-        fragment.context->getBoolType(), loIsNotZero, hiIsNotZero));
+      fragment.context->getBoolType(), loIsNotZero, hiIsNotZero));
     break;
   }
 
   case Sopp::Op::S_CBRANCH_EXECZ: {
     auto loIsZero = fragment.builder.createIEqual(
-        fragment.context->getBoolType(), fragment.getExecLo().value,
-        fragment.context->getUInt32(0));
+      fragment.context->getBoolType(), fragment.getExecLo().value,
+      fragment.context->getUInt32(0));
     auto hiIsZero = fragment.builder.createIEqual(
-        fragment.context->getBoolType(), fragment.getExecHi().value,
-        fragment.context->getUInt32(0));
+      fragment.context->getBoolType(), fragment.getExecHi().value,
+      fragment.context->getUInt32(0));
     createCondBranch(fragment.builder.createLogicalAnd(
-        fragment.context->getBoolType(), loIsZero, hiIsZero));
+      fragment.context->getBoolType(), loIsZero, hiIsZero));
     break;
   }
 
   case Sopp::Op::S_CBRANCH_EXECNZ: {
     auto loIsNotZero = fragment.builder.createINotEqual(
-        fragment.context->getBoolType(), fragment.getExecLo().value,
-        fragment.context->getUInt32(0));
+      fragment.context->getBoolType(), fragment.getExecLo().value,
+      fragment.context->getUInt32(0));
     auto hiIsNotZero = fragment.builder.createINotEqual(
-        fragment.context->getBoolType(), fragment.getExecHi().value,
-        fragment.context->getUInt32(0));
+      fragment.context->getBoolType(), fragment.getExecHi().value,
+      fragment.context->getUInt32(0));
 
     createCondBranch(fragment.builder.createLogicalOr(
-        fragment.context->getBoolType(), loIsNotZero, hiIsNotZero));
+      fragment.context->getBoolType(), loIsNotZero, hiIsNotZero));
     break;
   }
 
@@ -4854,7 +4854,7 @@ void Fragment::injectValuesFromPreds() {
     Value value;
 
     if (allSameValues) {
-      value = {type, predValues.back().first};
+      value = { type, predValues.back().first };
       // std::printf(" ** %s[%u] is value = %u\n", getRegName(id),
       // id.getOffset(),
       //             predValues.back().first.id);
@@ -4869,11 +4869,11 @@ void Fragment::injectValuesFromPreds() {
       //   std::printf("%u", value.first.id);
       // }
       // std::printf(" }\n");
-      value = {type, builder.createPhi(type, predValues)};
+      value = { type, builder.createPhi(type, predValues) };
     }
 
     registers->setRegister(id, value);
-  };
+    };
 
   for (auto id : values) {
     setupRegisterValue(id);
@@ -4904,7 +4904,7 @@ spirv::SamplerValue Fragment::createSampler(RegisterId base) {
     };
 
     auto uniform = context->getOrCreateUniformConstant(
-        sbuffer, std::size(sbuffer), TypeId::Sampler);
+      sbuffer, std::size(sbuffer), TypeId::Sampler);
     return builder.createLoad(context->getSamplerType(), uniform->variable);
   } else {
     util::unreachable();
@@ -4936,7 +4936,7 @@ spirv::ImageValue Fragment::createImage(RegisterId base, bool r128) {
     };
 
     auto uniform = context->getOrCreateUniformConstant(
-        sbuffer, std::size(sbuffer), TypeId::Image2D);
+      sbuffer, std::size(sbuffer), TypeId::Image2D);
     return builder.createLoad(context->getImage2DType(), uniform->variable);
   }
 
@@ -4962,7 +4962,7 @@ spirv::ImageValue Fragment::createImage(RegisterId base, bool r128) {
   };
 
   auto uniform = context->getOrCreateUniformConstant(
-      sbuffer, std::size(sbuffer), TypeId::Image2D);
+    sbuffer, std::size(sbuffer), TypeId::Image2D);
   return builder.createLoad(context->getImage2DType(), uniform->variable);
 }
 
@@ -4990,18 +4990,18 @@ Value Fragment::createCompositeExtract(Value composite, std::uint32_t member) {
     auto column = member % 4;
 
     auto rowType = context->getType(
-        static_cast<TypeId::enum_type>(static_cast<int>(baseType) + 3));
+      static_cast<TypeId::enum_type>(static_cast<int>(baseType) + 3));
 
     auto rowValue =
-        builder.createCompositeExtract(rowType, composite.value, {{row}});
+      builder.createCompositeExtract(rowType, composite.value, { {row} });
     resultValue =
-        builder.createCompositeExtract(resultType, rowValue, {{column}});
+      builder.createCompositeExtract(resultType, rowValue, { {column} });
   } else {
     resultValue =
-        builder.createCompositeExtract(resultType, composite.value, {{member}});
+      builder.createCompositeExtract(resultType, composite.value, { {member} });
   }
 
-  return {resultType, resultValue};
+  return { resultType, resultValue };
 }
 
 spirv::Value Fragment::createBitcast(spirv::Type to, spirv::Type from,
@@ -5106,7 +5106,7 @@ Value Fragment::getOperand(RegisterId id, TypeId type, OperandGetFlags flags) {
       members.push_back(member.value);
     }
 
-    return {resultType, builder.createCompositeConstruct(resultType, members)};
+    return { resultType, builder.createCompositeConstruct(resultType, members) };
   }
 
   if (registerElementsCount != 2) {
@@ -5136,20 +5136,20 @@ Value Fragment::getOperand(RegisterId id, TypeId type, OperandGetFlags flags) {
 
   auto uint64T = context->getUInt64Type();
   auto valueLo = builder.createUConvert(
-      uint64T,
-      spirv::cast<spirv::UIntValue>(getOperand(id, TypeId::UInt32).value));
+    uint64T,
+    spirv::cast<spirv::UIntValue>(getOperand(id, TypeId::UInt32).value));
   auto valueHi = builder.createUConvert(
-      uint64T, spirv::cast<spirv::UIntValue>(
-                   getOperand(RegisterId::Raw(id + 1), TypeId::UInt32).value));
+    uint64T, spirv::cast<spirv::UIntValue>(
+      getOperand(RegisterId::Raw(id + 1), TypeId::UInt32).value));
   valueHi =
-      builder.createShiftLeftLogical(uint64T, valueHi, context->getUInt32(32));
+    builder.createShiftLeftLogical(uint64T, valueHi, context->getUInt32(32));
   auto value = builder.createBitwiseOr(uint64T, valueLo, valueHi);
 
   if (baseTypeId != TypeId::UInt64) {
     value = createBitcast(baseType, context->getUInt64Type(), value);
   }
 
-  return {resultType, value};
+  return { resultType, value };
 }
 
 void Fragment::setOperand(RegisterId id, Value value) {
@@ -5181,13 +5181,13 @@ void Fragment::setOperand(RegisterId id, Value value) {
     if (value.type != boolT) {
       if (value.type == context->getUInt32Type()) {
         value.value =
-            builder.createINotEqual(boolT, value.value, context->getUInt32(0));
+          builder.createINotEqual(boolT, value.value, context->getUInt32(0));
       } else if (value.type == context->getSint32Type()) {
         value.value =
-            builder.createINotEqual(boolT, value.value, context->getSInt32(0));
+          builder.createINotEqual(boolT, value.value, context->getSInt32(0));
       } else if (value.type == context->getUInt64Type()) {
         value.value =
-            builder.createINotEqual(boolT, value.value, context->getUInt64(0));
+          builder.createINotEqual(boolT, value.value, context->getUInt64(0));
       } else {
         util::unreachable();
       }
@@ -5244,17 +5244,17 @@ void Fragment::setOperand(RegisterId id, Value value) {
     auto uint64_value = spirv::cast<spirv::UIntValue>(value.value);
     if (baseTypeId != TypeId::UInt64) {
       uint64_value = spirv::cast<spirv::UIntValue>(
-          createBitcast(uint64T, context->getType(baseTypeId), value.value));
+        createBitcast(uint64T, context->getType(baseTypeId), value.value));
     }
 
     auto uint32T = context->getUInt32Type();
     auto valueLo = builder.createUConvert(uint32T, uint64_value);
     auto valueHi = builder.createUConvert(
-        uint32T, builder.createShiftRightLogical(uint64T, uint64_value,
-                                                 context->getUInt32(32)));
+      uint32T, builder.createShiftRightLogical(uint64T, uint64_value,
+                                               context->getUInt32(32)));
 
-    setOperand(id, {uint32T, valueLo});
-    setOperand(RegisterId::Raw(id.raw + 1), {uint32T, valueHi});
+    setOperand(id, { uint32T, valueLo });
+    setOperand(RegisterId::Raw(id.raw + 1), { uint32T, valueHi });
   }
 }
 
@@ -5264,7 +5264,7 @@ void Fragment::setVcc(Value value) {
 
   setOperand(RegisterId::VccLo, value);
   setOperand(RegisterId::VccHi,
-             {context->getUInt32Type(), context->getUInt32(0)});
+             { context->getUInt32Type(), context->getUInt32(0) });
 }
 
 void Fragment::setScc(Value value) {
@@ -5280,7 +5280,7 @@ void Fragment::setScc(Value value) {
 
 spirv::BoolValue Fragment::getScc() {
   auto result =
-      getOperand(RegisterId::Scc, TypeId::Bool, OperandGetFlags::PreserveType);
+    getOperand(RegisterId::Scc, TypeId::Bool, OperandGetFlags::PreserveType);
 
   if (result.type == context->getBoolType()) {
     return spirv::cast<spirv::BoolValue>(result.value);
@@ -5368,30 +5368,30 @@ Value amdgpu::shader::Fragment::getRegister(RegisterId id) {
   if (id.isScalar()) {
     switch (id.getOffset()) {
     case 128 ... 192:
-      return {context->getSint32Type(), context->getSInt32(id - 128)};
+      return { context->getSint32Type(), context->getSInt32(id - 128) };
     case 193 ... 208:
-      return {context->getSint32Type(),
-              context->getSInt32(-static_cast<std::int32_t>(id - 192))};
+      return { context->getSint32Type(),
+              context->getSInt32(-static_cast<std::int32_t>(id - 192)) };
     case 240:
-      return {context->getFloat32Type(), context->getFloat32(0.5f)};
+      return { context->getFloat32Type(), context->getFloat32(0.5f) };
     case 241:
-      return {context->getFloat32Type(), context->getFloat32(-0.5f)};
+      return { context->getFloat32Type(), context->getFloat32(-0.5f) };
     case 242:
-      return {context->getFloat32Type(), context->getFloat32(1.0f)};
+      return { context->getFloat32Type(), context->getFloat32(1.0f) };
     case 243:
-      return {context->getFloat32Type(), context->getFloat32(-1.0f)};
+      return { context->getFloat32Type(), context->getFloat32(-1.0f) };
     case 244:
-      return {context->getFloat32Type(), context->getFloat32(2.0f)};
+      return { context->getFloat32Type(), context->getFloat32(2.0f) };
     case 245:
-      return {context->getFloat32Type(), context->getFloat32(-2.0f)};
+      return { context->getFloat32Type(), context->getFloat32(-2.0f) };
     case 246:
-      return {context->getFloat32Type(), context->getFloat32(4.0f)};
+      return { context->getFloat32Type(), context->getFloat32(4.0f) };
     case 247:
-      return {context->getFloat32Type(), context->getFloat32(-4.0f)};
+      return { context->getFloat32Type(), context->getFloat32(-4.0f) };
     case 255: {
       auto ptr = context->getMemory().getPointer<std::uint32_t>(registers->pc);
       registers->pc += sizeof(std::uint32_t);
-      return {context->getUInt32Type(), context->getUInt32(*ptr)};
+      return { context->getUInt32Type(), context->getUInt32(*ptr) };
     }
     }
   }
@@ -5413,7 +5413,7 @@ Value amdgpu::shader::Fragment::getRegister(RegisterId id) {
 }
 
 Value amdgpu::shader::Fragment::getRegister(RegisterId id,
-                                               spirv::Type type) {
+                                            spirv::Type type) {
   auto result = getRegister(id);
 
   if (!result) {
@@ -5424,7 +5424,7 @@ Value amdgpu::shader::Fragment::getRegister(RegisterId id,
     util::unreachable("%u is ulong\n", id.raw);
   }
 
-  return {type, createBitcast(type, result.type, result.value)};
+  return { type, createBitcast(type, result.type, result.value) };
 }
 
 void amdgpu::shader::Fragment::setRegister(RegisterId id, Value value) {

--- a/hw/amdgpu/shader/src/Function.cpp
+++ b/hw/amdgpu/shader/src/Function.cpp
@@ -1,6 +1,6 @@
-#include "Function.hpp"
-#include "ConverterContext.hpp"
-#include "RegisterId.hpp"
+#include "shader/Function.hpp"
+#include "shader/ConverterContext.hpp"
+#include "shader/RegisterId.hpp"
 
 using namespace amdgpu::shader;
 

--- a/hw/amdgpu/shader/src/scf.cpp
+++ b/hw/amdgpu/shader/src/scf.cpp
@@ -1,9 +1,10 @@
-#include "scf.hpp"
-#include "cf.hpp"
 #include <cassert>
 #include <fstream>
 #include <unordered_set>
 #include <utility>
+
+#include "shader/scf.hpp"
+#include "shader/cf.hpp"
 
 void scf::Block::eraseFrom(Node *endBefore) {
   mEnd = endBefore->getPrev();

--- a/orbis-kernel/examples/standalone/orbis-kernel-config/orbis-config.hpp
+++ b/orbis-kernel/examples/standalone/orbis-kernel-config/orbis-config.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
-#include "orbis/error.hpp"
-#include "orbis/thread/RegisterId.hpp"
 #include <cstdint>
 #include <cstring>
+
+#include "orbis/error.hpp"
+#include "orbis/thread/RegisterId.hpp"
 
 namespace orbis {
 using int8_t = std::int8_t;
@@ -27,18 +28,18 @@ using slong = int64_t;
 using ulong = uint64_t;
 
 template <typename T> using ptr = T *;
-template <typename T> using cptr = T * const;
+template <typename T> using cptr = T *const;
 
 using caddr_t = ptr<char>;
 
 inline ErrorCode uread(void *kernelAddress, ptr<const void> userAddress,
-                  size_t size) {
+                       size_t size) {
   std::memcpy(kernelAddress, userAddress, size);
   return {};
 }
 
 inline ErrorCode uwrite(ptr<void> userAddress, const void *kernelAddress,
-                   size_t size) {
+                        size_t size) {
   std::memcpy(userAddress, kernelAddress, size);
   return {};
 }

--- a/orbis-kernel/include/orbis/KernelAllocator.hpp
+++ b/orbis-kernel/include/orbis/KernelAllocator.hpp
@@ -1,16 +1,16 @@
 #pragma once
 
-#include "utils/Rc.hpp"
 #include <utility>
 #include <vector>
 #include <deque>
 #include <map>
 #include <unordered_map>
+#include "utils/Rc.hpp"
 
 namespace orbis {
 inline namespace utils {
 void *kalloc(std::size_t size, std::size_t align);
-void kfree(void* ptr, std::size_t size);
+void kfree(void *ptr, std::size_t size);
 template <typename T> struct kallocator {
   using value_type = T;
 
@@ -36,9 +36,9 @@ template <typename T> using kdeque = std::deque<T, kallocator<T>>;
 template <typename K, typename T, typename Cmp = std::less<>>
 using kmap = std::map<K, T, Cmp, kallocator<std::pair<const K, T>>>;
 template <typename K, typename T, typename Hash = std::hash<K>,
-          typename Pred = std::equal_to<K>>
-using kunmap =
-    std::unordered_map<K, T, Hash, Pred, kallocator<std::pair<const K, T>>>;
+  typename Pred = std::equal_to<K>>
+  using kunmap =
+  std::unordered_map<K, T, Hash, Pred, kallocator<std::pair<const K, T>>>;
 } // namespace utils
 
 template <typename T, typename... Args> T *knew(Args &&...args) {

--- a/orbis-kernel/include/orbis/KernelContext.hpp
+++ b/orbis-kernel/include/orbis/KernelContext.hpp
@@ -1,11 +1,13 @@
 #pragma once
+
+#include <algorithm>
+#include <utility>
+
 #include "utils/LinkedNode.hpp"
 #include "utils/SharedMutex.hpp"
 
 #include "orbis/thread/types.hpp"
-#include "KernelAllocator.hpp"
-#include <algorithm>
-#include <utility>
+#include "orbis/KernelAllocator.hpp"
 
 namespace orbis {
 struct Process;

--- a/orbis-kernel/include/orbis/error/SysResult.hpp
+++ b/orbis-kernel/include/orbis/error/SysResult.hpp
@@ -8,7 +8,7 @@ class SysResult {
 
 public:
   SysResult() = default;
-  SysResult(ErrorCode ec) : mValue(-static_cast<int>(ec)){}
+  SysResult(ErrorCode ec) : mValue(-static_cast<int>(ec)) {}
 
   [[nodiscard]] static SysResult notAnError(ErrorCode ec) {
     SysResult result;

--- a/orbis-kernel/include/orbis/module/Module.hpp
+++ b/orbis-kernel/include/orbis/module/Module.hpp
@@ -1,15 +1,14 @@
 #pragma once
 
-#include "ModuleHandle.hpp"
-#include "ModuleSegment.hpp"
-
-#include "../utils/Rc.hpp"
-#include "../KernelAllocator.hpp"
-
-#include "orbis-config.hpp"
 #include <cstddef>
 #include <vector>
 #include <string>
+
+#include "ModuleHandle.hpp"
+#include "ModuleSegment.hpp"
+#include "../utils/Rc.hpp"
+#include "../KernelAllocator.hpp"
+#include "orbis-config.hpp"
 
 namespace orbis {
 struct Thread;
@@ -118,7 +117,7 @@ struct Module final {
   utils::kvector<utils::Ref<Module>> namespaceModules;
   utils::kvector<std::string> needed;
 
-  std::atomic<unsigned> references{0};
+  std::atomic<unsigned> references{ 0 };
   unsigned _total_size = 0;
 
   void incRef() {

--- a/orbis-kernel/include/orbis/module/ModuleInfo.hpp
+++ b/orbis-kernel/include/orbis/module/ModuleInfo.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "ModuleSegment.hpp"
-
 #include "orbis-config.hpp"
 
 namespace orbis {

--- a/orbis-kernel/include/orbis/module/ModuleInfoEx.hpp
+++ b/orbis-kernel/include/orbis/module/ModuleInfoEx.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "ModuleSegment.hpp"
-
 #include "orbis-config.hpp"
 
 namespace orbis {

--- a/orbis-kernel/include/orbis/sys/sysentry.hpp
+++ b/orbis-kernel/include/orbis/sys/sysentry.hpp
@@ -11,5 +11,5 @@ extern sysentvec ps5_sysvec;
 
 struct Thread;
 void syscall_entry(Thread *thread);
-const char *getSysentName(SysResult (*sysent)(Thread *, uint64_t *));
+const char *getSysentName(SysResult(*sysent)(Thread *, uint64_t *));
 } // namespace orbis

--- a/orbis-kernel/include/orbis/sys/sysproto.hpp
+++ b/orbis-kernel/include/orbis/sys/sysproto.hpp
@@ -1,6 +1,7 @@
+#include <array>
+
 #include <orbis/error.hpp>
 #include <orbis/thread.hpp>
-#include <array>
 
 namespace orbis {
 using acl_type_t = sint;

--- a/orbis-kernel/include/orbis/thread/Process.hpp
+++ b/orbis-kernel/include/orbis/thread/Process.hpp
@@ -1,4 +1,7 @@
 #pragma once
+
+#include <mutex>
+
 #include "ProcessState.hpp"
 #include "orbis-config.hpp"
 #include "orbis/module/Module.hpp"
@@ -6,8 +9,6 @@
 #include "orbis/utils/SharedMutex.hpp"
 #include "../thread/types.hpp"
 #include "../thread/Thread.hpp"
-
-#include <mutex>
 
 namespace orbis {
 class KernelContext;

--- a/orbis-kernel/include/orbis/thread/Process.hpp
+++ b/orbis-kernel/include/orbis/thread/Process.hpp
@@ -2,13 +2,13 @@
 
 #include <mutex>
 
-#include "ProcessState.hpp"
-#include "orbis-config.hpp"
+#include "thread/ProcessState.hpp"
+#include "orbis-kernel-config/orbis-config.hpp"
 #include "orbis/module/Module.hpp"
 #include "orbis/utils/IdMap.hpp"
 #include "orbis/utils/SharedMutex.hpp"
-#include "../thread/types.hpp"
-#include "../thread/Thread.hpp"
+#include "thread/types.hpp"
+#include "thread/Thread.hpp"
 
 namespace orbis {
 class KernelContext;

--- a/orbis-kernel/include/orbis/thread/ProcessOps.hpp
+++ b/orbis-kernel/include/orbis/thread/ProcessOps.hpp
@@ -9,48 +9,48 @@ struct Thread;
 struct Module;
 
 struct ProcessOps {
-  SysResult (*mmap)(Thread *thread, caddr_t addr, size_t len, sint prot, sint flags, sint fd, off_t pos);
-  SysResult (*munmap)(Thread *thread, ptr<void> addr, size_t len);
-  SysResult (*msync)(Thread *thread, ptr<void> addr, size_t len, sint flags);
-  SysResult (*mprotect)(Thread *thread, ptr<const void> addr, size_t len, sint prot);
-  SysResult (*minherit)(Thread *thread, ptr<void> addr, size_t len, sint inherit);
-  SysResult (*madvise)(Thread *thread, ptr<void> addr, size_t len, sint behav);
-  SysResult (*mincore)(Thread *thread, ptr<const void> addr, size_t len, ptr<char> vec);
-  SysResult (*mlock)(Thread *thread, ptr<const void> addr, size_t len);
-  SysResult (*mlockall)(Thread *thread, sint how);
-  SysResult (*munlockall)(Thread *thread);
-  SysResult (*munlock)(Thread *thread, ptr<const void> addr, size_t len);
-  SysResult (*virtual_query)(Thread *thread, ptr<const void> addr, sint flags, ptr<void> info, ulong infoSize);
+  SysResult(*mmap)(Thread *thread, caddr_t addr, size_t len, sint prot, sint flags, sint fd, off_t pos);
+  SysResult(*munmap)(Thread *thread, ptr<void> addr, size_t len);
+  SysResult(*msync)(Thread *thread, ptr<void> addr, size_t len, sint flags);
+  SysResult(*mprotect)(Thread *thread, ptr<const void> addr, size_t len, sint prot);
+  SysResult(*minherit)(Thread *thread, ptr<void> addr, size_t len, sint inherit);
+  SysResult(*madvise)(Thread *thread, ptr<void> addr, size_t len, sint behav);
+  SysResult(*mincore)(Thread *thread, ptr<const void> addr, size_t len, ptr<char> vec);
+  SysResult(*mlock)(Thread *thread, ptr<const void> addr, size_t len);
+  SysResult(*mlockall)(Thread *thread, sint how);
+  SysResult(*munlockall)(Thread *thread);
+  SysResult(*munlock)(Thread *thread, ptr<const void> addr, size_t len);
+  SysResult(*virtual_query)(Thread *thread, ptr<const void> addr, sint flags, ptr<void> info, ulong infoSize);
 
-  SysResult (*open)(Thread *thread, ptr<const char> path, sint flags, sint mode);
-  SysResult (*close)(Thread *thread, sint fd);
-  SysResult (*ioctl)(Thread *thread, sint fd, ulong com, caddr_t argp);
-  SysResult (*write)(Thread *thread, sint fd, ptr<const void> data, ulong size);
-  SysResult (*read)(Thread *thread, sint fd, ptr<void> data, ulong size);
-  SysResult (*pread)(Thread *thread, sint fd, ptr<void> data, ulong size, ulong offset);
-  SysResult (*pwrite)(Thread *thread, sint fd, ptr<const void> data, ulong size, ulong offset);
-  SysResult (*lseek)(Thread *thread, sint fd, ulong offset, sint whence);
-  SysResult (*ftruncate)(Thread *thread, sint fd, off_t length);
-  SysResult (*truncate)(Thread *thread, ptr<const char> path, off_t length);
+  SysResult(*open)(Thread *thread, ptr<const char> path, sint flags, sint mode);
+  SysResult(*close)(Thread *thread, sint fd);
+  SysResult(*ioctl)(Thread *thread, sint fd, ulong com, caddr_t argp);
+  SysResult(*write)(Thread *thread, sint fd, ptr<const void> data, ulong size);
+  SysResult(*read)(Thread *thread, sint fd, ptr<void> data, ulong size);
+  SysResult(*pread)(Thread *thread, sint fd, ptr<void> data, ulong size, ulong offset);
+  SysResult(*pwrite)(Thread *thread, sint fd, ptr<const void> data, ulong size, ulong offset);
+  SysResult(*lseek)(Thread *thread, sint fd, ulong offset, sint whence);
+  SysResult(*ftruncate)(Thread *thread, sint fd, off_t length);
+  SysResult(*truncate)(Thread *thread, ptr<const char> path, off_t length);
 
-  SysResult (*dynlib_get_obj_member)(Thread *thread, ModuleHandle handle, uint64_t index, ptr<ptr<void>> addrp);
-  SysResult (*dynlib_dlsym)(Thread *thread, ModuleHandle handle, ptr<const char> symbol, ptr<ptr<void>> addrp);
-  SysResult (*dynlib_do_copy_relocations)(Thread *thread);
-  SysResult (*dynlib_load_prx)(Thread *thread, ptr<const char> name, uint64_t arg1, ptr<ModuleHandle> pHandle, uint64_t arg3);
-  SysResult (*dynlib_unload_prx)(Thread *thread, ModuleHandle handle);
+  SysResult(*dynlib_get_obj_member)(Thread *thread, ModuleHandle handle, uint64_t index, ptr<ptr<void>> addrp);
+  SysResult(*dynlib_dlsym)(Thread *thread, ModuleHandle handle, ptr<const char> symbol, ptr<ptr<void>> addrp);
+  SysResult(*dynlib_do_copy_relocations)(Thread *thread);
+  SysResult(*dynlib_load_prx)(Thread *thread, ptr<const char> name, uint64_t arg1, ptr<ModuleHandle> pHandle, uint64_t arg3);
+  SysResult(*dynlib_unload_prx)(Thread *thread, ModuleHandle handle);
 
-  SysResult (*thr_create)(Thread *thread, ptr<struct ucontext> ctxt, ptr<slong> arg, sint flags);
-  SysResult (*thr_new)(Thread *thread, ptr<struct thr_param> param, sint param_size);
-  SysResult (*thr_exit)(Thread *thread, ptr<slong> state);
-  SysResult (*thr_kill)(Thread *thread, slong id, sint sig);
-  SysResult (*thr_kill2)(Thread *thread, pid_t pid, slong id, sint sig);
-  SysResult (*thr_suspend)(Thread *thread, ptr<const struct timespec> timeout);
-  SysResult (*thr_wake)(Thread *thread, slong id);
-  SysResult (*thr_set_name)(Thread *thread, slong id, ptr<const char> name);
+  SysResult(*thr_create)(Thread *thread, ptr<struct ucontext> ctxt, ptr<slong> arg, sint flags);
+  SysResult(*thr_new)(Thread *thread, ptr<struct thr_param> param, sint param_size);
+  SysResult(*thr_exit)(Thread *thread, ptr<slong> state);
+  SysResult(*thr_kill)(Thread *thread, slong id, sint sig);
+  SysResult(*thr_kill2)(Thread *thread, pid_t pid, slong id, sint sig);
+  SysResult(*thr_suspend)(Thread *thread, ptr<const struct timespec> timeout);
+  SysResult(*thr_wake)(Thread *thread, slong id);
+  SysResult(*thr_set_name)(Thread *thread, slong id, ptr<const char> name);
 
-  SysResult (*exit)(Thread *thread, sint status);
+  SysResult(*exit)(Thread *thread, sint status);
 
-  SysResult (*processNeeded)(Thread *thread);
-  SysResult (*registerEhFrames)(Thread *thread);
+  SysResult(*processNeeded)(Thread *thread);
+  SysResult(*registerEhFrames)(Thread *thread);
 };
 } // namespace orbis

--- a/orbis-kernel/include/orbis/thread/Thread.hpp
+++ b/orbis-kernel/include/orbis/thread/Thread.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "orbis-config.hpp"
-#include "types.hpp"
-#include "ThreadState.hpp"
+#include "orbis-kernel-config/orbis-config.hpp"
+#include "thread/types.hpp"
+#include "thread/ThreadState.hpp"
 
 #include "../utils/SharedMutex.hpp"
 

--- a/orbis-kernel/include/orbis/utils/AtomicOp.hpp
+++ b/orbis-kernel/include/orbis/utils/AtomicOp.hpp
@@ -18,12 +18,12 @@ atomic_fetch_op(std::atomic<T> &v, F func) {
       std::invoke(func, _new);
       if (v.compare_exchange_strong(old, _new)) [[likely]] {
         return old;
-      }
+        }
     } else {
       RT ret = std::invoke(func, _new);
       if (!ret || v.compare_exchange_strong(old, _new)) [[likely]] {
-        return {old, std::move(ret)};
-      }
+        return { old, std::move(ret) };
+        }
     }
   }
 }
@@ -38,12 +38,12 @@ inline RT atomic_op(std::atomic<T> &v, F func) {
       std::invoke(func, _new);
       if (v.compare_exchange_strong(old, _new)) [[likely]] {
         return;
-      }
+        }
     } else {
       RT result = std::invoke(func, _new);
       if (v.compare_exchange_strong(old, _new)) [[likely]] {
         return result;
-      }
+        }
     }
   }
 }

--- a/orbis-kernel/include/orbis/utils/BitSet.hpp
+++ b/orbis-kernel/include/orbis/utils/BitSet.hpp
@@ -30,7 +30,7 @@ template <std::size_t Count> struct BitSet {
 
     if (auto chunkOffset = offset % BitsPerChunk) {
       auto count =
-          std::countr_zero(_bits[offset / BitsPerChunk] >> chunkOffset);
+        std::countr_zero(_bits[offset / BitsPerChunk] >> chunkOffset);
 
       if (count != BitsPerChunk) {
         return count + offset;
@@ -87,12 +87,12 @@ template <std::size_t Count> struct BitSet {
 
   constexpr void clear(std::size_t index) {
     _bits[index / BitsPerChunk] &=
-        ~(static_cast<chunk_type>(1) << (index % BitsPerChunk));
+      ~(static_cast<chunk_type>(1) << (index % BitsPerChunk));
   }
 
   constexpr void set(std::size_t index) {
     _bits[index / BitsPerChunk] |= static_cast<chunk_type>(1)
-                                   << (index % BitsPerChunk);
+      << (index % BitsPerChunk);
   }
 
   constexpr bool test(std::size_t index) const {

--- a/orbis-kernel/include/orbis/utils/IdMap.hpp
+++ b/orbis-kernel/include/orbis/utils/IdMap.hpp
@@ -1,23 +1,23 @@
 #pragma once
 
-#include "BitSet.hpp"
-#include "Rc.hpp"
-
-#include <algorithm>
 #include <bit>
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <type_traits>
 
+#include "BitSet.hpp"
+#include "Rc.hpp"
+
 namespace orbis {
 inline namespace utils {
 template <WithRc T, typename IdT = int, std::size_t MaxId = 4096,
-          std::size_t MinId = 0>
+  std::size_t MinId = 0>
   requires(MaxId > MinId)
 class RcIdMap {
   static constexpr auto ChunkSize = std::min<std::size_t>(MaxId - MinId, 64);
   static constexpr auto ChunkCount =
-      (MaxId - MinId + ChunkSize - 1) / ChunkSize;
+    (MaxId - MinId + ChunkSize - 1) / ChunkSize;
 
   struct IdMapChunk {
     BitSet<ChunkSize> mask = {};
@@ -72,8 +72,8 @@ public:
     }
 
     std::pair<IdT, T *> operator*() const {
-      return {static_cast<IdT>(chunk * ChunkSize + index + MinId),
-              chunks[chunk].objects[index]};
+      return { static_cast<IdT>(chunk * ChunkSize + index + MinId),
+              chunks[chunk].objects[index] };
     }
 
     bool operator!=(const end_iterator &) const { return chunk < ChunkCount; }
@@ -107,7 +107,7 @@ public:
     }
   }
 
-  iterator begin() const { return iterator{m_chunks}; }
+  iterator begin() const { return iterator{ m_chunks }; }
 
   end_iterator end() const { return {}; }
 
@@ -125,7 +125,7 @@ private:
       m_fullChunks.set(page);
     }
 
-    return {static_cast<IdT>(page * ChunkSize + index + MinId)};
+    return { static_cast<IdT>(page * ChunkSize + index + MinId) };
   }
 
 public:
@@ -190,12 +190,12 @@ public:
 };
 
 template <typename T, typename IdT = int, std::size_t MaxId = 4096,
-          std::size_t MinId = 0>
+  std::size_t MinId = 0>
   requires(MaxId > MinId)
 struct OwningIdMap {
   static constexpr auto ChunkSize = std::min<std::size_t>(MaxId - MinId, 64);
   static constexpr auto ChunkCount =
-      (MaxId - MinId + ChunkSize - 1) / ChunkSize;
+    (MaxId - MinId + ChunkSize - 1) / ChunkSize;
 
   struct IdMapChunk {
     BitSet<ChunkSize> mask = {};
@@ -232,8 +232,8 @@ struct OwningIdMap {
 
       mask.set(index);
 
-      return {index,
-              std::construct_at(get(index), std::forward<ArgsT>(args)...)};
+      return { index,
+              std::construct_at(get(index), std::forward<ArgsT>(args)...) };
     }
 
     T *get(std::size_t index) {
@@ -264,8 +264,8 @@ struct OwningIdMap {
       fullChunks.set(page);
     }
 
-    return {static_cast<IdT>(page * ChunkSize + newElem.first + MinId),
-            newElem.second};
+    return { static_cast<IdT>(page * ChunkSize + newElem.first + MinId),
+            newElem.second };
   }
 
   T *get(IdT id) {

--- a/orbis-kernel/include/orbis/utils/Logs.hpp
+++ b/orbis-kernel/include/orbis/utils/Logs.hpp
@@ -1,6 +1,7 @@
 #pragma once
-#include <atomic>
+
 #include <span>
+#include <atomic>
 #include <string>
 
 namespace orbis {

--- a/orbis-kernel/include/orbis/utils/Rc.hpp
+++ b/orbis-kernel/include/orbis/utils/Rc.hpp
@@ -8,10 +8,10 @@
 namespace orbis {
 template <typename T, typename... Args> T *knew(Args &&...args);
 inline namespace utils {
-void kfree(void* ptr, std::size_t size);
+void kfree(void *ptr, std::size_t size);
 
 struct RcBase {
-  std::atomic<unsigned> references{0};
+  std::atomic<unsigned> references{ 0 };
   unsigned _total_size = 0; // Set by knew/kcreate
 
   virtual ~RcBase() = default;

--- a/orbis-kernel/include/orbis/utils/SharedMutex.hpp
+++ b/orbis-kernel/include/orbis/utils/SharedMutex.hpp
@@ -31,7 +31,7 @@ public:
     // Conditional increment
     unsigned value = m_value.load();
     return value < c_one - 1 &&
-           m_value.compare_exchange_strong(value, value + 1);
+      m_value.compare_exchange_strong(value, value + 1);
   }
 
   // Lock with HLE acquire hint
@@ -41,8 +41,8 @@ public:
       unsigned old = value;
       if (compare_exchange_hle_acq(m_value, old, value + 1)) [[likely]] {
         return;
+        }
       }
-    }
 
     impl_lock_shared(value + 1);
   }
@@ -52,7 +52,7 @@ public:
     const unsigned value = fetch_add_hle_rel(m_value, -1u);
     if (value >= c_one) [[unlikely]] {
       impl_unlock_shared(value);
-    }
+      }
   }
 
   bool try_lock() {
@@ -65,7 +65,7 @@ public:
     unsigned value = 0;
     if (!compare_exchange_hle_acq(m_value, value, +c_one)) [[unlikely]] {
       impl_lock(value);
-    }
+      }
   }
 
   // Unlock with HLE release hint
@@ -73,7 +73,7 @@ public:
     const unsigned value = fetch_add_hle_rel(m_value, 0u - c_one);
     if (value != c_one) [[unlikely]] {
       impl_unlock(value);
-    }
+      }
   }
 
   bool try_lock_upgrade() {
@@ -82,13 +82,13 @@ public:
     // Conditional increment, try to convert a single reader into a writer,
     // ignoring other writers
     return (value + c_one - 1) % c_one == 0 &&
-           m_value.compare_exchange_strong(value, value + c_one - 1);
+      m_value.compare_exchange_strong(value, value + c_one - 1);
   }
 
   void lock_upgrade() {
     if (!try_lock_upgrade()) [[unlikely]] {
       impl_lock_upgrade();
-    }
+      }
   }
 
   void lock_downgrade() {

--- a/orbis-kernel/src/module.cpp
+++ b/orbis-kernel/src/module.cpp
@@ -1,9 +1,9 @@
-#include "module/Module.hpp"
-#include "thread.hpp"
 #include <utility>
+#include <string_view>
 
 #include "thread/Process.hpp"
-#include <string_view>
+#include "module/Module.hpp"
+#include "orbis/thread.hpp"
 
 // TODO: move relocations to the platform specific code
 enum RelType {
@@ -60,8 +60,8 @@ static void allocateTlsOffset(orbis::Process *process, orbis::Module *module) {
   }
 
   auto offset =
-      calculateTlsOffset(module->tlsIndex == 1 ? 0 : process->lastTlsOffset,
-                         module->tlsSize, module->tlsAlign);
+    calculateTlsOffset(module->tlsIndex == 1 ? 0 : process->lastTlsOffset,
+                       module->tlsSize, module->tlsAlign);
 
   module->tlsOffset = offset;
   process->lastTlsOffset = offset;
@@ -136,7 +136,7 @@ static orbis::SysResult doRelocation(orbis::Process *process,
       std::printf("Requested library is '%s', exists in libraries: [",
                   library.name.c_str());
 
-      for (bool isFirst = true; auto &lib : foundInLibs) {
+      for (bool isFirst = true; auto & lib : foundInLibs) {
         if (isFirst) {
           isFirst = false;
         } else {
@@ -148,7 +148,7 @@ static orbis::SysResult doRelocation(orbis::Process *process,
       std::printf("]\n");
     }
     return std::pair(module, symbol.address);
-  };
+    };
 
   switch (rel.relType) {
   case kRelNone:
@@ -158,14 +158,14 @@ static orbis::SysResult doRelocation(orbis::Process *process,
     *where = reinterpret_cast<std::uintptr_t>(defObj->base) + S + A;
     return {};
   }
-    return {};
+             return {};
   case kRelPc32: {
     auto [defObj, S] = findDefModule();
     *where32 = reinterpret_cast<std::uintptr_t>(defObj->base) + S + A - P;
     return {};
   }
-  // case kRelCopy:
-  //   return{};
+               // case kRelCopy:
+               //   return{};
   case kRelGlobDat: {
     auto [defObj, S] = findDefModule();
     *where = reinterpret_cast<std::uintptr_t>(defObj->base) + S;

--- a/orbis-kernel/src/sys/sys_acct.cpp
+++ b/orbis-kernel/src/sys/sys_acct.cpp
@@ -1,4 +1,4 @@
 #include "sys/sysproto.hpp"
-#include "error.hpp"
+#include "orbis/error.hpp"
 
 orbis::SysResult orbis::sys_acct(Thread *thread, ptr<char> path) { return ErrorCode::NOSYS; }

--- a/orbis-kernel/src/sys/sys_exit.cpp
+++ b/orbis-kernel/src/sys/sys_exit.cpp
@@ -9,5 +9,3 @@ orbis::SysResult orbis::sys_exit(Thread *thread, sint status) {
 }
 orbis::SysResult orbis::sys_abort2(Thread *thread, ptr<const char> why, sint narg, ptr<ptr<void>> args) { return ErrorCode::NOSYS; }
 orbis::SysResult orbis::sys_wait4(Thread *thread, sint pid, ptr<sint> status, sint options, ptr<struct rusage> rusage) { return ErrorCode::NOSYS; }
-
-

--- a/orbis-kernel/src/sys/sys_sce.cpp
+++ b/orbis-kernel/src/sys/sys_sce.cpp
@@ -1,4 +1,4 @@
-#include "error.hpp"
+#include "orbis/error.hpp"
 #include "module/ModuleInfo.hpp"
 #include "module/ModuleInfoEx.hpp"
 #include "sys/sysproto.hpp"
@@ -392,8 +392,8 @@ orbis::SysResult orbis::sys_mdbg_service(Thread *thread, uint32_t op, ptr<void> 
   case 1: {
     auto *prop = (mdbg_property *)arg0;
     std::printf(
-        "sys_mdbg_service set property (name='%s', address=0x%lx, size=%lu)\n",
-        prop->name, prop->addr_ptr, prop->areaSize);
+      "sys_mdbg_service set property (name='%s', address=0x%lx, size=%lu)\n",
+      prop->name, prop->addr_ptr, prop->areaSize);
     break;
   }
 
@@ -548,9 +548,9 @@ orbis::SysResult orbis::sys_ipmimgr_call(Thread *thread, uint64_t id, uint64_t a
     auto createParams = (ptr<IpmiCreateClientParams>)params;
 
     std::printf("ipmi create client(%p, '%s', %p)\n",
-      (void *)createParams->arg0,
-      (char *)createParams->name,
-      (void *)createParams->arg2
+                (void *)createParams->arg0,
+                (char *)createParams->name,
+                (void *)createParams->arg2
     );
 
     return{};

--- a/orbis-kernel/src/sys/sys_sysctl.cpp
+++ b/orbis-kernel/src/sys/sys_sysctl.cpp
@@ -154,12 +154,12 @@ orbis::SysResult orbis::sys___sysctl(Thread *thread, ptr<sint> name,
         }
 
         auto processParam =
-            reinterpret_cast<std::byte *>(thread->tproc->processParam);
+          reinterpret_cast<std::byte *>(thread->tproc->processParam);
 
         auto sdkVersion = processParam        //
-                          + sizeof(uint64_t)  // size
-                          + sizeof(uint32_t)  // magic
-                          + sizeof(uint32_t); // entryCount
+          + sizeof(uint64_t)  // size
+          + sizeof(uint32_t)  // magic
+          + sizeof(uint32_t); // entryCount
 
         std::printf("Reporting SDK version %x\n",
                     *reinterpret_cast<uint32_t *>(sdkVersion));

--- a/orbis-kernel/src/sys/sys_vm_mmap.cpp
+++ b/orbis-kernel/src/sys/sys_vm_mmap.cpp
@@ -1,4 +1,4 @@
-#include "error.hpp"
+#include "orbis/error.hpp"
 #include "sys/sysproto.hpp"
 
 orbis::SysResult orbis::sys_sbrk(Thread *, sint) {
@@ -93,7 +93,7 @@ orbis::SysResult orbis::sys_munlockall(Thread *thread) {
 }
 orbis::SysResult orbis::sys_munlock(Thread *thread, ptr<const void> addr,
                                     size_t len) {
-   if (auto impl = thread->tproc->ops->munlock) {
+  if (auto impl = thread->tproc->ops->munlock) {
     return impl(thread, addr, len);
   }
 

--- a/orbis-kernel/src/sysvec.cpp
+++ b/orbis-kernel/src/sysvec.cpp
@@ -1,7 +1,8 @@
+#include <unordered_map>
+
 #include "sys/syscall.hpp"
 #include "sys/sysproto.hpp"
 #include "sys/sysentry.hpp"
-#include <unordered_map>
 
 enum { PSL_C = 0x1 };
 
@@ -78,7 +79,7 @@ namespace orbis {
 namespace detail {
 template <auto Fn> struct WrapImpl;
 
-template <typename... Args, SysResult (*Fn)(Thread *, Args...)>
+template <typename... Args, SysResult(*Fn)(Thread *, Args...)>
   requires(sizeof...(Args) < 8)
 struct WrapImpl<Fn> {
   constexpr sysent operator()() {
@@ -106,7 +107,7 @@ template <auto Fn> constexpr auto wrap() -> decltype(detail::WrapImpl<Fn>()()) {
   return detail::WrapImpl<Fn>()();
 }
 
-static const std::unordered_map<SysResult (*)(Thread *, uint64_t *), const char *> gImplToName = {
+static const std::unordered_map<SysResult(*)(Thread *, uint64_t *), const char *> gImplToName = {
   {wrap<nosys>().call, "nosys"},
   {wrap<sys_exit>().call, "sys_exit"},
   {wrap<sys_fork>().call, "sys_fork"},
@@ -680,7 +681,7 @@ static const std::unordered_map<SysResult (*)(Thread *, uint64_t *), const char 
   {wrap<sys_workspace_ctrl>().call, "sys_workspace_ctrl"},
 };
 
-const char *getSysentName(SysResult (*sysent)(Thread *, uint64_t *)) {
+const char *getSysentName(SysResult(*sysent)(Thread *, uint64_t *)) {
   auto it = gImplToName.find(sysent);
   if (it == gImplToName.end()) {
     return nullptr;

--- a/orbis-kernel/src/utils/Logs.cpp
+++ b/orbis-kernel/src/utils/Logs.cpp
@@ -1,10 +1,11 @@
-#include "utils/Logs.hpp"
 #include <sstream>
 #include <string>
 #include <string_view>
 #include <vector>
 #include <cstdarg>
 #include <cstdint>
+
+#include "utils/Logs.hpp"
 
 static void append_hex(std::string &out, std::uintmax_t value) {
   std::ostringstream buf;

--- a/orbis-kernel/src/utils/SharedMutex.cpp
+++ b/orbis-kernel/src/utils/SharedMutex.cpp
@@ -1,8 +1,9 @@
-#include "utils/SharedMutex.hpp"
 #include <linux/futex.h>
 #include <syscall.h>
 #include <unistd.h>
 #include <xmmintrin.h>
+
+#include "utils/SharedMutex.hpp"
 
 static void busy_wait(unsigned long long cycles = 3000) {
   const auto stop = __builtin_ia32_rdtsc() + cycles;
@@ -67,7 +68,7 @@ void shared_mutex::impl_wait() {
       }
 
       return false;
-    });
+                                           });
 
     if (ok) {
       break;

--- a/rpcsx-gpu/main.cpp
+++ b/rpcsx-gpu/main.cpp
@@ -1,19 +1,20 @@
-#include <algorithm>
-#include <amdgpu/bridge/bridge.hpp>
-#include <amdgpu/device/device.hpp>
-#include <chrono>
-#include <csignal>
-#include <cstdio>
 #include <fcntl.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
-#include <thread>
 #include <unistd.h>
-#include <util/VerifyVulkan.hpp>
 #include <vulkan/vulkan.h>
 #include <vulkan/vulkan_core.h>
-
 #include <GLFW/glfw3.h> // TODO: make in optional
+
+#include <algorithm>
+#include <chrono>
+#include <csignal>
+#include <cstdio>
+#include <thread>
+
+#include <amdgpu/bridge/bridge.hpp>
+#include <amdgpu/device/device.hpp>
+#include <util/VerifyVulkan.hpp>
 
 // TODO
 extern void *g_rwMemory;
@@ -27,8 +28,8 @@ static void usage(std::FILE *out, const char *argv0) {
                "    --cmd-bridge <name> - setup command queue bridge name\n");
   std::fprintf(out, "    --shm <name> - setup shared memory name\n");
   std::fprintf(
-      out,
-      "    --gpu <index> - specify physical gpu index to use, default is 0\n");
+    out,
+    "    --gpu <index> - specify physical gpu index to use, default is 0\n");
   std::fprintf(out,
                "    --presenter <presenter mode> - set flip engine target\n");
   std::fprintf(out, "    -h, --help - show this message\n");
@@ -118,7 +119,7 @@ int main(int argc, const char *argv[]) {
   glfwExtensions = glfwGetRequiredInstanceExtensions(&glfwExtensionCount);
 
   auto requiredInstanceExtensions = std::vector<const char *>(
-      glfwExtensions, glfwExtensions + glfwExtensionCount);
+    glfwExtensions, glfwExtensions + glfwExtensionCount);
 
   bool enableValidation = true;
 
@@ -133,7 +134,7 @@ int main(int argc, const char *argv[]) {
   if (extCount > 0) {
     std::vector<VkExtensionProperties> extensions(extCount);
     if (vkEnumerateInstanceExtensionProperties(
-            nullptr, &extCount, &extensions.front()) == VK_SUCCESS) {
+      nullptr, &extCount, &extensions.front()) == VK_SUCCESS) {
       supportedInstanceExtensions.reserve(extensions.size());
       for (VkExtensionProperties extension : extensions) {
         supportedInstanceExtensions.push_back(extension.extensionName);
@@ -166,7 +167,7 @@ int main(int argc, const char *argv[]) {
   instanceCreateInfo.pApplicationInfo = &appInfo;
   instanceCreateInfo.enabledExtensionCount = requiredInstanceExtensions.size();
   instanceCreateInfo.ppEnabledExtensionNames =
-      requiredInstanceExtensions.data();
+    requiredInstanceExtensions.data();
 
   if (enableValidation) {
     instanceCreateInfo.ppEnabledLayerNames = &validationLayerName;
@@ -181,7 +182,7 @@ int main(int argc, const char *argv[]) {
     Verify() << vkEnumeratePhysicalDevices(vkInstance, &count, devices.data());
     Verify() << (index < count);
     return devices[index];
-  };
+    };
 
   auto vkPhysicalDevice = getVkPhyDevice(gpuIndex);
 
@@ -194,17 +195,17 @@ int main(int argc, const char *argv[]) {
                                       &vkPhyDeviceMemoryProperties);
 
   VkPhysicalDevice8BitStorageFeatures storage_8bit = {
-      .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_8BIT_STORAGE_FEATURES};
+      .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_8BIT_STORAGE_FEATURES };
   VkPhysicalDevice16BitStorageFeatures storage_16bit = {
       .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES,
-      .pNext = &storage_8bit};
+      .pNext = &storage_8bit };
   VkPhysicalDeviceShaderFloat16Int8Features float16_int8 = {
       .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES,
-      .pNext = &storage_16bit};
+      .pNext = &storage_16bit };
 
   VkPhysicalDeviceFeatures2 features2 = {
       .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2,
-      .pNext = &float16_int8};
+      .pNext = &float16_int8 };
   vkGetPhysicalDeviceFeatures2(vkPhysicalDevice, &features2);
 
   Verify() << storage_8bit.uniformAndStorageBuffer8BitAccess;
@@ -236,7 +237,7 @@ int main(int argc, const char *argv[]) {
     return std::find(vkSupportedDeviceExtensions.begin(),
                      vkSupportedDeviceExtensions.end(),
                      extension) != vkSupportedDeviceExtensions.end();
-  };
+    };
 
   std::vector<const char *> requestedDeviceExtensions = {
       VK_EXT_DEPTH_RANGE_UNRESTRICTED_EXTENSION_NAME,
@@ -259,9 +260,9 @@ int main(int argc, const char *argv[]) {
   for (const char *requestedExtension : requestedDeviceExtensions) {
     if (!isDeviceExtensionSupported(requestedExtension)) {
       std::fprintf(
-          stderr,
-          "Requested device extension '%s' is not present at device level\n",
-          requestedExtension);
+        stderr,
+        "Requested device extension '%s' is not present at device level\n",
+        requestedExtension);
       std::abort();
     }
   }
@@ -279,7 +280,7 @@ int main(int argc, const char *argv[]) {
     }
 
     vkGetPhysicalDeviceQueueFamilyProperties2(
-        vkPhysicalDevice, &queueFamilyCount, queueFamilyProperties.data());
+      vkPhysicalDevice, &queueFamilyCount, queueFamilyProperties.data());
   }
 
   VkSurfaceKHR vkSurface;
@@ -335,20 +336,20 @@ int main(int argc, const char *argv[]) {
        ++queueFamily) {
     if (queueFamiliesWithGraphicsSupport.contains(queueFamily)) {
       requestedQueues.push_back(
-          {.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO,
-           .queueFamilyIndex = queueFamily,
-           .queueCount = 1,
-           .pQueuePriorities = defaultQueuePriorities.data()});
+        { .sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO,
+         .queueFamilyIndex = queueFamily,
+         .queueCount = 1,
+         .pQueuePriorities = defaultQueuePriorities.data() });
     } else if (queueFamiliesWithComputeSupport.contains(queueFamily) ||
                queueFamiliesWithTransferSupport.contains(queueFamily)) {
       requestedQueues.push_back(
-          {.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO,
-           .queueFamilyIndex = queueFamily,
-           .queueCount =
-               std::min<uint32_t>(queueFamilyProperties[queueFamily]
-                                      .queueFamilyProperties.queueCount,
-                                  defaultQueuePriorities.size()),
-           .pQueuePriorities = defaultQueuePriorities.data()});
+        { .sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO,
+         .queueFamilyIndex = queueFamily,
+         .queueCount =
+             std::min<uint32_t>(queueFamilyProperties[queueFamily]
+                                    .queueFamilyProperties.queueCount,
+                                defaultQueuePriorities.size()),
+         .pQueuePriorities = defaultQueuePriorities.data() });
     }
   }
 
@@ -370,10 +371,10 @@ int main(int argc, const char *argv[]) {
 
     if (!alreadyRequested) {
       requestedQueues.push_back(
-          {.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO,
-           .queueFamilyIndex = queueFamily,
-           .queueCount = 1,
-           .pQueuePriorities = defaultQueuePriorities.data()});
+        { .sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO,
+         .queueFamilyIndex = queueFamily,
+         .queueCount = 1,
+         .pQueuePriorities = defaultQueuePriorities.data() });
     }
 
     requestedPresentQueue = true;
@@ -392,10 +393,10 @@ int main(int argc, const char *argv[]) {
 
       if (!alreadyRequested) {
         requestedQueues.push_back(
-            {.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO,
-             .queueFamilyIndex = queueFamily,
-             .queueCount = 1,
-             .pQueuePriorities = defaultQueuePriorities.data()});
+          { .sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO,
+           .queueFamilyIndex = queueFamily,
+           .queueCount = 1,
+           .pQueuePriorities = defaultQueuePriorities.data() });
       }
 
       requestedPresentQueue = true;
@@ -404,7 +405,7 @@ int main(int argc, const char *argv[]) {
 
   VkPhysicalDeviceVulkan13Features phyDevFeatures13{
       .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES,
-      .maintenance4 = VK_TRUE};
+      .maintenance4 = VK_TRUE };
 
   VkPhysicalDeviceVulkan12Features phyDevFeatures12{
       .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES,
@@ -430,7 +431,7 @@ int main(int argc, const char *argv[]) {
       .enabledExtensionCount =
           static_cast<uint32_t>(requestedDeviceExtensions.size()),
       .ppEnabledExtensionNames = requestedDeviceExtensions.data(),
-      .pEnabledFeatures = &features2.features};
+      .pEnabledFeatures = &features2.features };
 
   VkDevice vkDevice;
   Verify() << vkCreateDevice(vkPhysicalDevice, &deviceCreateInfo, nullptr,
@@ -450,7 +451,7 @@ int main(int argc, const char *argv[]) {
 
   std::vector<VkSurfaceFormatKHR> surfaceFormats(formatCount);
   Verify() << vkGetPhysicalDeviceSurfaceFormatsKHR(
-      vkPhysicalDevice, vkSurface, &formatCount, surfaceFormats.data());
+    vkPhysicalDevice, vkSurface, &formatCount, surfaceFormats.data());
 
   if ((formatCount == 1) && (surfaceFormats[0].format == VK_FORMAT_UNDEFINED)) {
     swapchainColorFormat = VK_FORMAT_B8G8R8A8_UNORM;
@@ -480,12 +481,12 @@ int main(int argc, const char *argv[]) {
                                                           vkSurface, &surfCaps);
     uint32_t presentModeCount;
     Verify() << vkGetPhysicalDeviceSurfacePresentModesKHR(
-        vkPhysicalDevice, vkSurface, &presentModeCount, NULL);
+      vkPhysicalDevice, vkSurface, &presentModeCount, NULL);
     Verify() << (presentModeCount > 0);
 
     std::vector<VkPresentModeKHR> presentModes(presentModeCount);
     Verify() << vkGetPhysicalDeviceSurfacePresentModesKHR(
-        vkPhysicalDevice, vkSurface, &presentModeCount, presentModes.data());
+      vkPhysicalDevice, vkSurface, &presentModeCount, presentModes.data());
 
     if (surfCaps.currentExtent.width != (uint32_t)-1) {
       swapchainExtent = surfCaps.currentExtent;
@@ -518,7 +519,7 @@ int main(int argc, const char *argv[]) {
     }
 
     VkCompositeAlphaFlagBitsKHR compositeAlpha =
-        VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
+      VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
     std::vector<VkCompositeAlphaFlagBitsKHR> compositeAlphaFlags = {
         VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR,
         VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR,
@@ -539,7 +540,7 @@ int main(int argc, const char *argv[]) {
     swapchainCI.minImageCount = desiredNumberOfSwapchainImages;
     swapchainCI.imageFormat = swapchainColorFormat;
     swapchainCI.imageColorSpace = swapchainColorSpace;
-    swapchainCI.imageExtent = {swapchainExtent.width, swapchainExtent.height};
+    swapchainCI.imageExtent = { swapchainExtent.width, swapchainExtent.height };
     swapchainCI.imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
     swapchainCI.preTransform = (VkSurfaceTransformFlagBitsKHR)preTransform;
     swapchainCI.imageArrayLayers = 1;
@@ -571,8 +572,8 @@ int main(int argc, const char *argv[]) {
 
     swapchainImages.resize(swapchainImageCount);
     Verify() << vkGetSwapchainImagesKHR(
-        vkDevice, swapchain, &swapchainImageCount, swapchainImages.data());
-  };
+      vkDevice, swapchain, &swapchainImageCount, swapchainImages.data());
+    };
 
   createSwapchain();
 
@@ -641,10 +642,10 @@ int main(int argc, const char *argv[]) {
   Verify() << vkCreatePipelineCache(vkDevice, &pipelineCacheCreateInfo, nullptr,
                                     &pipelineCache);
   amdgpu::device::DrawContext dc{
-      // TODO
-      .pipelineCache = pipelineCache,
-      .queue = graphicsQueues.front().first,
-      .commandPool = commandPool,
+    // TODO
+    .pipelineCache = pipelineCache,
+    .queue = graphicsQueues.front().first,
+    .commandPool = commandPool,
   };
 
   std::vector<VkFence> inFlightFences(swapchainImages.size());
@@ -686,7 +687,7 @@ int main(int argc, const char *argv[]) {
 
   bridge->pullerPid = ::getpid();
 
-  amdgpu::bridge::BridgePuller bridgePuller{bridge};
+  amdgpu::bridge::BridgePuller bridgePuller{ bridge };
   amdgpu::bridge::Command commandsBuffer[32];
 
   int memoryFd = ::shm_open(shmName, O_RDWR, S_IRUSR | S_IWUSR);
@@ -697,8 +698,8 @@ int main(int argc, const char *argv[]) {
 
   struct stat memoryStat;
   ::fstat(memoryFd, &memoryStat);
-  amdgpu::RemoteMemory memory{(char *)::mmap(
-      nullptr, memoryStat.st_size, PROT_NONE, MAP_SHARED, memoryFd, 0)};
+  amdgpu::RemoteMemory memory{ (char *)::mmap(
+      nullptr, memoryStat.st_size, PROT_NONE, MAP_SHARED, memoryFd, 0) };
 
   extern void *g_rwMemory;
   g_memorySize = memoryStat.st_size;
@@ -730,13 +731,13 @@ int main(int argc, const char *argv[]) {
   swapchainImageHandles.resize(swapchainImages.size());
 
   VkPipelineStageFlags submitPipelineStages =
-      VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+    VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
 
   while (!glfwWindowShouldClose(window)) {
     glfwPollEvents();
 
     std::size_t pulledCount =
-        bridgePuller.pullCommands(commandsBuffer, std::size(commandsBuffer));
+      bridgePuller.pullCommands(commandsBuffer, std::size(commandsBuffer));
 
     if (pulledCount == 0) {
       // std::this_thread::sleep_for(

--- a/rpcsx-os/bridge.cpp
+++ b/rpcsx-os/bridge.cpp
@@ -1,4 +1,3 @@
 #include "bridge.hpp"
 
 amdgpu::bridge::BridgePusher rx::bridge;
-

--- a/rpcsx-os/bridge.cpp
+++ b/rpcsx-os/bridge.cpp
@@ -1,3 +1,3 @@
-#include "bridge.hpp"
+#include "rpcsx-os/bridge.hpp"
 
 amdgpu::bridge::BridgePusher rx::bridge;

--- a/rpcsx-os/io-device.cpp
+++ b/rpcsx-os/io-device.cpp
@@ -1,8 +1,10 @@
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <string>
+
 #include "io-device.hpp"
 #include "orbis/KernelAllocator.hpp"
-#include <fcntl.h>
-#include <string>
-#include <unistd.h>
 
 std::int64_t io_device_instance_close(IoDeviceInstance *instance) {
   return 0;

--- a/rpcsx-os/io-device.cpp
+++ b/rpcsx-os/io-device.cpp
@@ -3,7 +3,7 @@
 
 #include <string>
 
-#include "io-device.hpp"
+#include "rpcsx-os/io-device.hpp"
 #include "orbis/KernelAllocator.hpp"
 
 std::int64_t io_device_instance_close(IoDeviceInstance *instance) {

--- a/rpcsx-os/io-device.hpp
+++ b/rpcsx-os/io-device.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "orbis/utils/Rc.hpp"
 #include <cstdint>
+#include "orbis/utils/Rc.hpp"
 
 struct IoDevice;
 

--- a/rpcsx-os/iodev/dce.cpp
+++ b/rpcsx-os/iodev/dce.cpp
@@ -1,11 +1,12 @@
-#include "bridge.hpp"
-#include "io-device.hpp"
-#include "orbis/KernelAllocator.hpp"
 #include <cinttypes>
 #include <cstddef>
 #include <cstdio>
 #include <cstring>
+
 #include "vm.hpp"
+#include "bridge.hpp"
+#include "io-device.hpp"
+#include "orbis/KernelAllocator.hpp"
 
 struct VideoOutBuffer {
   std::uint32_t pixelFormat;
@@ -174,15 +175,15 @@ static std::int64_t dce_instance_ioctl(IoDeviceInstance *instance,
     auto args = reinterpret_cast<RegisterBufferAttributeArgs *>(argp);
 
     std::fprintf(
-        stderr,
-        "dce: RegisterBufferAttributes(unk0=%lx, unk1=%x, unk2_flag=%x, "
-        "unk3=%x, "
-        "pixelFormat=%x, tilingMode=%x, pitch=%u, width=%u, "
-        "height=%u, "
-        "unk4_zero=%x, unk5_zero=%x, unk6=%x, unk7_-1=%lx, unk8=%x)\n",
-        args->unk0, args->unk1, args->unk2_flag, args->unk3, args->pixelFormat,
-        args->tilingMode, args->pitch, args->width, args->height,
-        args->unk4_zero, args->unk5_zero, args->unk6, args->unk7, args->unk8);
+      stderr,
+      "dce: RegisterBufferAttributes(unk0=%lx, unk1=%x, unk2_flag=%x, "
+      "unk3=%x, "
+      "pixelFormat=%x, tilingMode=%x, pitch=%u, width=%u, "
+      "height=%u, "
+      "unk4_zero=%x, unk5_zero=%x, unk6=%x, unk7_-1=%lx, unk8=%x)\n",
+      args->unk0, args->unk1, args->unk2_flag, args->unk3, args->pixelFormat,
+      args->tilingMode, args->pitch, args->width, args->height,
+      args->unk4_zero, args->unk5_zero, args->unk6, args->unk7, args->unk8);
 
     dceInstance->bufferAttributes.pixelFormat = args->pixelFormat;
     dceInstance->bufferAttributes.tilingMode = args->tilingMode;
@@ -197,13 +198,13 @@ static std::int64_t dce_instance_ioctl(IoDeviceInstance *instance,
     auto args = reinterpret_cast<FlipRequestArgs *>(argp);
 
     std::fprintf(
-        stderr,
-        "dce: FlipRequestArgs(%lx, displayBufferIndex = %x, flipMode = %lx, "
-        "flipArg = %lx, "
-        "%x, %x, %x, "
-        "%x)\n",
-        args->arg1, args->displayBufferIndex, args->flipMode, args->flipArg,
-        args->arg5, args->arg6, args->arg7, args->arg8);
+      stderr,
+      "dce: FlipRequestArgs(%lx, displayBufferIndex = %x, flipMode = %lx, "
+      "flipArg = %lx, "
+      "%x, %x, %x, "
+      "%x)\n",
+      args->arg1, args->displayBufferIndex, args->flipMode, args->flipArg,
+      args->arg5, args->arg6, args->arg7, args->arg8);
 
     rx::bridge.sendFlip(args->displayBufferIndex, /*args->flipMode,*/ args->flipArg);
 

--- a/rpcsx-os/iodev/dce.cpp
+++ b/rpcsx-os/iodev/dce.cpp
@@ -3,9 +3,9 @@
 #include <cstdio>
 #include <cstring>
 
-#include "vm.hpp"
-#include "bridge.hpp"
-#include "io-device.hpp"
+#include "rpcsx-os/vm.hpp"
+#include "rpcsx-os/bridge.hpp"
+#include "rpcsx-os/io-device.hpp"
 #include "orbis/KernelAllocator.hpp"
 
 struct VideoOutBuffer {

--- a/rpcsx-os/iodev/dipsw.cpp
+++ b/rpcsx-os/iodev/dipsw.cpp
@@ -1,6 +1,7 @@
+#include <cstdio>
+
 #include "io-device.hpp"
 #include "orbis/KernelAllocator.hpp"
-#include <cstdio>
 
 struct DmemDevice : public IoDevice {
 };
@@ -42,7 +43,7 @@ static std::int64_t dipsw_instance_ioctl(IoDeviceInstance *instance,
   }
 
   std::fprintf(stderr, "***ERROR*** Unhandled dipsw ioctl %lx\n", request);
-   std::fflush(stdout);
+  std::fflush(stdout);
   //__builtin_trap();
   return 0;
 }

--- a/rpcsx-os/iodev/dmem.cpp
+++ b/rpcsx-os/iodev/dmem.cpp
@@ -1,8 +1,9 @@
-#include "io-device.hpp"
-#include "orbis/KernelAllocator.hpp"
 #include <cinttypes>
 #include <cstdio>
+
 #include "vm.hpp"
+#include "io-device.hpp"
+#include "orbis/KernelAllocator.hpp"
 
 struct DmemDevice : public IoDevice {
   int index;
@@ -22,7 +23,7 @@ struct AllocateDirectMemoryArgs {
 
 static constexpr auto dmemSize = 4ul * 1024 * 1024 * 1024;
 // static const std::uint64_t nextOffset = 0;
-//  static const std::uint64_t memBeginAddress = 0xfe0000000;
+// static const std::uint64_t memBeginAddress = 0xfe0000000;
 
 static std::int64_t dmem_instance_ioctl(IoDeviceInstance *instance,
                                         std::uint64_t request, void *argp) {
@@ -42,14 +43,14 @@ static std::int64_t dmem_instance_ioctl(IoDeviceInstance *instance,
   case 0xc0288001: { // sceKernelAllocateDirectMemory
     auto args = reinterpret_cast<AllocateDirectMemoryArgs *>(argp);
     auto alignedOffset =
-        (device->nextOffset + args->alignment - 1) & ~(args->alignment - 1);
+      (device->nextOffset + args->alignment - 1) & ~(args->alignment - 1);
 
     std::fprintf(
-        stderr,
-        "dmem%u allocateDirectMemory(searchStart = %lx, searchEnd = %lx, len "
-        "= %lx, alignment = %lx, memoryType = %x) -> 0x%lx\n",
-        device->index, args->searchStart, args->searchEnd, args->len,
-        args->alignment, args->memoryType, alignedOffset);
+      stderr,
+      "dmem%u allocateDirectMemory(searchStart = %lx, searchEnd = %lx, len "
+      "= %lx, alignment = %lx, memoryType = %x) -> 0x%lx\n",
+      device->index, args->searchStart, args->searchEnd, args->len,
+      args->alignment, args->memoryType, alignedOffset);
 
     if (alignedOffset + args->len > dmemSize) {
       return -1;
@@ -69,8 +70,8 @@ static std::int64_t dmem_instance_ioctl(IoDeviceInstance *instance,
     auto args = reinterpret_cast<Args *>(argp);
 
     std::fprintf(
-        stderr, "TODO: dmem%u releaseDirectMemory(address=0x%lx, size=0x%lx)\n",
-        device->index, args->address, args->size);
+      stderr, "TODO: dmem%u releaseDirectMemory(address=0x%lx, size=0x%lx)\n",
+      device->index, args->address, args->size);
     //std::fflush(stdout);
     //__builtin_trap();
     return 0;
@@ -97,8 +98,8 @@ static void *dmem_instance_mmap(IoDeviceInstance *instance, void *address,
                offset, device->memBeginAddress + offset);
 
   auto addr =
-      rx::vm::map(reinterpret_cast<void *>(device->memBeginAddress + offset), size,
-               prot, flags);
+    rx::vm::map(reinterpret_cast<void *>(device->memBeginAddress + offset), size,
+                prot, flags);
   return addr;
 }
 

--- a/rpcsx-os/iodev/dmem.cpp
+++ b/rpcsx-os/iodev/dmem.cpp
@@ -1,8 +1,8 @@
 #include <cinttypes>
 #include <cstdio>
 
-#include "vm.hpp"
-#include "io-device.hpp"
+#include "rpcsx-os/vm.hpp"
+#include "rpcsx-os/io-device.hpp"
 #include "orbis/KernelAllocator.hpp"
 
 struct DmemDevice : public IoDevice {

--- a/rpcsx-os/iodev/gc.cpp
+++ b/rpcsx-os/iodev/gc.cpp
@@ -1,17 +1,19 @@
-#include "bridge.hpp"
-#include "io-device.hpp"
-#include "orbis/KernelAllocator.hpp"
+#include <sys/mman.h>
+
 #include <atomic>
 #include <cinttypes>
 #include <cstdio>
 #include <cstring>
-// #include <rpcs4/bridge.hpp>
-#include "vm.hpp"
 #include <string>
-#include <sys/mman.h>
 #include <thread>
 #include <type_traits>
 #include <utility>
+
+#include "vm.hpp"
+#include "bridge.hpp"
+#include "io-device.hpp"
+#include "orbis/KernelAllocator.hpp"
+// #include <rpcs4/bridge.hpp>
 
 struct GcDevice : public IoDevice {};
 
@@ -26,7 +28,7 @@ static std::int64_t gc_instance_ioctl(IoDeviceInstance *instance,
 
   switch (request) {
   case 0xc008811b: // get submit done flag ptr?
-                   // TODO
+    // TODO
     std::fprintf(stderr, "gc ioctl 0xc008811b(%lx)\n", *(std::uint64_t *)argp);
     *reinterpret_cast<void **>(argp) = &g_submitDoneFlag;
     return 0;
@@ -146,9 +148,9 @@ static std::int64_t gc_instance_ioctl(IoDeviceInstance *instance,
     };
     auto args = reinterpret_cast<Args *>(argp);
     std::fprintf(
-        stderr,
-        "gc ioctl stats report control(unk=%x,arg1=%x,arg2=%x,arg3=%x)\n",
-        args->unk, args->arg1, args->arg2, args->arg3);
+      stderr,
+      "gc ioctl stats report control(unk=%x,arg1=%x,arg2=%x,arg3=%x)\n",
+      args->unk, args->arg1, args->arg2, args->arg3);
     break;
   }
 

--- a/rpcsx-os/iodev/gc.cpp
+++ b/rpcsx-os/iodev/gc.cpp
@@ -9,9 +9,9 @@
 #include <type_traits>
 #include <utility>
 
-#include "vm.hpp"
-#include "bridge.hpp"
-#include "io-device.hpp"
+#include "rpcsx-os/vm.hpp"
+#include "rpcsx-os/bridge.hpp"
+#include "rpcsx-os/io-device.hpp"
 #include "orbis/KernelAllocator.hpp"
 // #include <rpcs4/bridge.hpp>
 

--- a/rpcsx-os/iodev/hid.cpp
+++ b/rpcsx-os/iodev/hid.cpp
@@ -1,9 +1,9 @@
 #include <cinttypes>
 #include <cstdio>
 
-#include "io-device.hpp"
+#include "rpcsx-os/io-device.hpp"
+#include "rpcsx-os/vm.hpp"
 #include "orbis/KernelAllocator.hpp"
-#include "vm.hpp"
 
 struct HidDevice : public IoDevice {};
 struct HidInstance : public IoDeviceInstance {};

--- a/rpcsx-os/iodev/hid.cpp
+++ b/rpcsx-os/iodev/hid.cpp
@@ -1,8 +1,9 @@
+#include <cinttypes>
+#include <cstdio>
+
 #include "io-device.hpp"
 #include "orbis/KernelAllocator.hpp"
 #include "vm.hpp"
-#include <cinttypes>
-#include <cstdio>
 
 struct HidDevice : public IoDevice {};
 struct HidInstance : public IoDeviceInstance {};

--- a/rpcsx-os/iodev/hmd_3da.cpp
+++ b/rpcsx-os/iodev/hmd_3da.cpp
@@ -1,6 +1,6 @@
 #include <cstdio>
 
-#include "io-device.hpp"
+#include "rpcsx-os/io-device.hpp"
 #include "orbis/KernelAllocator.hpp"
 
 struct Hmd3daDevice : public IoDevice {

--- a/rpcsx-os/iodev/hmd_3da.cpp
+++ b/rpcsx-os/iodev/hmd_3da.cpp
@@ -1,6 +1,7 @@
+#include <cstdio>
+
 #include "io-device.hpp"
 #include "orbis/KernelAllocator.hpp"
-#include <cstdio>
 
 struct Hmd3daDevice : public IoDevice {
 };

--- a/rpcsx-os/iodev/hmd_cmd.cpp
+++ b/rpcsx-os/iodev/hmd_cmd.cpp
@@ -1,6 +1,7 @@
+#include <cstdio>
+
 #include "io-device.hpp"
 #include "orbis/KernelAllocator.hpp"
-#include <cstdio>
 
 struct HmdCmdDevice : public IoDevice {
 };
@@ -12,7 +13,7 @@ static std::int64_t hmd_cmd_instance_ioctl(IoDeviceInstance *instance,
                                            std::uint64_t request, void *argp) {
 
   std::fprintf(stderr, "***ERROR*** Unhandled hmd_cmd ioctl %lx\n",
-        request);
+               request);
   return -1;
 }
 

--- a/rpcsx-os/iodev/hmd_cmd.cpp
+++ b/rpcsx-os/iodev/hmd_cmd.cpp
@@ -1,6 +1,6 @@
 #include <cstdio>
 
-#include "io-device.hpp"
+#include "rpcsx-os/io-device.hpp"
 #include "orbis/KernelAllocator.hpp"
 
 struct HmdCmdDevice : public IoDevice {

--- a/rpcsx-os/iodev/hmd_mmap.cpp
+++ b/rpcsx-os/iodev/hmd_mmap.cpp
@@ -1,9 +1,9 @@
 #include <cinttypes>
 #include <cstdio>
 
-#include "io-device.hpp"
+#include "rpcsx-os/io-device.hpp"
+#include "rpcsx-os/vm.hpp"
 #include "orbis/KernelAllocator.hpp"
-#include "vm.hpp"
 
 struct HmdMmapDevice : public IoDevice {};
 

--- a/rpcsx-os/iodev/hmd_mmap.cpp
+++ b/rpcsx-os/iodev/hmd_mmap.cpp
@@ -1,8 +1,9 @@
+#include <cinttypes>
+#include <cstdio>
+
 #include "io-device.hpp"
 #include "orbis/KernelAllocator.hpp"
 #include "vm.hpp"
-#include <cinttypes>
-#include <cstdio>
 
 struct HmdMmapDevice : public IoDevice {};
 
@@ -13,23 +14,23 @@ static std::int64_t hmd_mmap_instance_ioctl(IoDeviceInstance *instance,
                                             std::uint64_t request, void *argp) {
 
   std::fprintf(stderr, "***ERROR*** Unhandled hmd_mmap ioctl %lx\n",
-        request);
+               request);
   std::fflush(stdout);
   __builtin_trap();
   return -1;
 }
 
-static void * hmd_mmap_instance_mmap(IoDeviceInstance *instance,
-                                           void *address, std::uint64_t size,
-                                           std::int32_t prot,
-                                           std::int32_t flags,
-                                           std::int64_t offset) {
+static void *hmd_mmap_instance_mmap(IoDeviceInstance *instance,
+                                    void *address, std::uint64_t size,
+                                    std::int32_t prot,
+                                    std::int32_t flags,
+                                    std::int64_t offset) {
   std::fprintf(stderr, "***ERROR*** Unhandled hmd_mmap mmap %lx\n", offset);
   return rx::vm::map(address, size, prot, flags);
 }
 
 static std::int32_t hmd_mmap_device_open(IoDevice *device,
-                                         orbis::Ref<IoDeviceInstance>  *instance,
+                                         orbis::Ref<IoDeviceInstance> *instance,
                                          const char *path, std::uint32_t flags,
                                          std::uint32_t mode) {
   auto *newInstance = orbis::knew<HmdMmapInstance>();

--- a/rpcsx-os/iodev/hmd_snsr.cpp
+++ b/rpcsx-os/iodev/hmd_snsr.cpp
@@ -1,6 +1,7 @@
+#include <cstdio>
+
 #include "io-device.hpp"
 #include "orbis/KernelAllocator.hpp"
-#include <cstdio>
 
 struct HmdSnsrDevice : public IoDevice {};
 
@@ -11,12 +12,12 @@ static std::int64_t smd_snr_instance_ioctl(IoDeviceInstance *instance,
                                            std::uint64_t request, void *argp) {
 
   std::fprintf(stderr, "***ERROR*** Unhandled hmd_snsr ioctl %lx\n",
-        request);
+               request);
   return -1;
 }
 
 static std::int32_t smd_snr_device_open(IoDevice *device,
-                                        orbis::Ref<IoDeviceInstance>  *instance,
+                                        orbis::Ref<IoDeviceInstance> *instance,
                                         const char *path, std::uint32_t flags,
                                         std::uint32_t mode) {
   auto *newInstance = orbis::knew<HmdSnsrInstance>();

--- a/rpcsx-os/iodev/hmd_snsr.cpp
+++ b/rpcsx-os/iodev/hmd_snsr.cpp
@@ -1,6 +1,6 @@
 #include <cstdio>
 
-#include "io-device.hpp"
+#include "rpcsx-os/io-device.hpp"
 #include "orbis/KernelAllocator.hpp"
 
 struct HmdSnsrDevice : public IoDevice {};

--- a/rpcsx-os/iodev/null.cpp
+++ b/rpcsx-os/iodev/null.cpp
@@ -11,9 +11,9 @@ static std::int64_t null_instance_write(IoDeviceInstance *instance,
   return size;
 }
 
-static std::int32_t null_device_open(IoDevice *device, orbis::Ref<IoDeviceInstance>  *instance,
-                              const char *path, std::uint32_t flags,
-                              std::uint32_t mode) {
+static std::int32_t null_device_open(IoDevice *device, orbis::Ref<IoDeviceInstance> *instance,
+                                     const char *path, std::uint32_t flags,
+                                     std::uint32_t mode) {
   auto *newInstance = orbis::knew<NullInstance>();
   newInstance->write = null_instance_write;
 

--- a/rpcsx-os/iodev/null.cpp
+++ b/rpcsx-os/iodev/null.cpp
@@ -1,4 +1,4 @@
-#include "io-device.hpp"
+#include "rpcsx-os/io-device.hpp"
 #include "orbis/KernelAllocator.hpp"
 
 struct NullDevice : public IoDevice {};

--- a/rpcsx-os/iodev/rng.cpp
+++ b/rpcsx-os/iodev/rng.cpp
@@ -1,9 +1,9 @@
 #include <cinttypes>
 #include <cstdio>
 
-#include "io-device.hpp"
+#include "rpcsx-os/io-device.hpp"
+#include "rpcsx-os/vm.hpp"
 #include "orbis/KernelAllocator.hpp"
-#include "vm.hpp"
 
 struct RngDevice : public IoDevice {};
 struct RngInstance : public IoDeviceInstance {};

--- a/rpcsx-os/iodev/rng.cpp
+++ b/rpcsx-os/iodev/rng.cpp
@@ -1,8 +1,9 @@
+#include <cinttypes>
+#include <cstdio>
+
 #include "io-device.hpp"
 #include "orbis/KernelAllocator.hpp"
 #include "vm.hpp"
-#include <cinttypes>
-#include <cstdio>
 
 struct RngDevice : public IoDevice {};
 struct RngInstance : public IoDeviceInstance {};

--- a/rpcsx-os/iodev/stderr.cpp
+++ b/rpcsx-os/iodev/stderr.cpp
@@ -1,6 +1,6 @@
 #include <fstream>
 
-#include "io-device.hpp"
+#include "rpcsx-os/io-device.hpp"
 #include "orbis/KernelAllocator.hpp"
 
 struct StderrInstance : public IoDeviceInstance {};

--- a/rpcsx-os/iodev/stderr.cpp
+++ b/rpcsx-os/iodev/stderr.cpp
@@ -1,6 +1,7 @@
+#include <fstream>
+
 #include "io-device.hpp"
 #include "orbis/KernelAllocator.hpp"
-#include <fstream>
 
 struct StderrInstance : public IoDeviceInstance {};
 

--- a/rpcsx-os/iodev/stdin.cpp
+++ b/rpcsx-os/iodev/stdin.cpp
@@ -1,4 +1,4 @@
-#include "io-device.hpp"
+#include "rpcsx-os/io-device.hpp"
 #include "orbis/KernelAllocator.hpp"
 
 struct StdinDevice : public IoDevice {

--- a/rpcsx-os/iodev/stdin.cpp
+++ b/rpcsx-os/iodev/stdin.cpp
@@ -8,7 +8,7 @@ struct StdinInstance : public IoDeviceInstance {
 };
 
 static std::int64_t stdin_instance_read(IoDeviceInstance *instance, void *data,
-                         std::uint64_t size) {
+                                        std::uint64_t size) {
   return -1;
 }
 

--- a/rpcsx-os/iodev/stdout.cpp
+++ b/rpcsx-os/iodev/stdout.cpp
@@ -1,7 +1,7 @@
-#include "io-device.hpp"
-#include "orbis/KernelAllocator.hpp"
 #include <cstdio>
 
+#include "io-device.hpp"
+#include "orbis/KernelAllocator.hpp"
 
 struct StdoutInstance : public IoDeviceInstance {};
 

--- a/rpcsx-os/iodev/stdout.cpp
+++ b/rpcsx-os/iodev/stdout.cpp
@@ -1,6 +1,6 @@
 #include <cstdio>
 
-#include "io-device.hpp"
+#include "rpcsx-os/io-device.hpp"
 #include "orbis/KernelAllocator.hpp"
 
 struct StdoutInstance : public IoDeviceInstance {};

--- a/rpcsx-os/iodev/zero.cpp
+++ b/rpcsx-os/iodev/zero.cpp
@@ -1,6 +1,6 @@
 #include <cstring>
 
-#include "io-device.hpp"
+#include "rpcsx-os/io-device.hpp"
 #include "orbis/KernelAllocator.hpp"
 
 struct ZeroDevice : public IoDevice {

--- a/rpcsx-os/iodev/zero.cpp
+++ b/rpcsx-os/iodev/zero.cpp
@@ -1,6 +1,7 @@
+#include <cstring>
+
 #include "io-device.hpp"
 #include "orbis/KernelAllocator.hpp"
-#include <cstring>
 
 struct ZeroDevice : public IoDevice {
 };
@@ -15,7 +16,7 @@ static std::int64_t zero_device_read(IoDeviceInstance *instance, void *data,
 }
 
 static std::int32_t zero_device_open(IoDevice *device,
-                                     orbis::Ref<IoDeviceInstance>  *instance,
+                                     orbis::Ref<IoDeviceInstance> *instance,
                                      const char *path, std::uint32_t flags,
                                      std::uint32_t mode) {
   auto *newInstance = orbis::knew<ZeroInstance>();

--- a/rpcsx-os/linker.cpp
+++ b/rpcsx-os/linker.cpp
@@ -6,13 +6,13 @@
 #include <memory>
 #include <unordered_map>
 
-#include "linker.hpp"
-#include "align.hpp"
-#include "io-device.hpp"
+#include "rpcsx-os/linker.hpp"
+#include "rpcsx-os/align.hpp"
+#include "rpcsx-os/io-device.hpp"
+#include "rpcsx-os/vfs.hpp"
+#include "rpcsx-os/vm.hpp"
 #include "orbis/KernelAllocator.hpp"
 #include "orbis/module/Module.hpp"
-#include "vfs.hpp"
-#include "vm.hpp"
 #include <orbis/thread/Process.hpp>
 
 using orbis::utils::Ref;

--- a/rpcsx-os/linker.cpp
+++ b/rpcsx-os/linker.cpp
@@ -5,6 +5,11 @@
 #include <map>
 #include <memory>
 #include <unordered_map>
+#include <functional>
+#include <utility>
+#include <algorithm>
+#include <vector>
+#include <string>
 
 #include "rpcsx-os/linker.hpp"
 #include "rpcsx-os/align.hpp"

--- a/rpcsx-os/linker.hpp
+++ b/rpcsx-os/linker.hpp
@@ -78,4 +78,4 @@ void override(std::string originalModuleName, std::filesystem::path replacedModu
 orbis::Ref<orbis::Module> loadModule(std::span<std::byte> image, orbis::Process *process);
 orbis::Ref<orbis::Module> loadModuleFile(const char *path, orbis::Process *process);
 orbis::Ref<orbis::Module> loadModuleByName(std::string_view name, orbis::Process *process);
-} // namespace re::loader
+} // namespace rx::linker

--- a/rpcsx-os/linker.hpp
+++ b/rpcsx-os/linker.hpp
@@ -1,15 +1,16 @@
 #pragma once
 
-#include "orbis/module/Module.hpp"
-#include "orbis/utils/Rc.hpp"
 #include <cstddef>
 #include <filesystem>
 #include <optional>
 #include <span>
 
+#include "orbis/module/Module.hpp"
+#include "orbis/utils/Rc.hpp"
+
 namespace rx::linker {
 inline constexpr char nidLookup[] =
-    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+-";
+"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+-";
 
 constexpr std::optional<std::uint64_t> decodeNid(std::string_view nid) {
   std::uint64_t result = 0;
@@ -45,12 +46,12 @@ struct nid {
 };
 
 constexpr nid encodeNid(std::uint64_t hash) {
-  return {{nidLookup[(hash >> 58) & 0x3f], nidLookup[(hash >> 52) & 0x3f],
+  return { {nidLookup[(hash >> 58) & 0x3f], nidLookup[(hash >> 52) & 0x3f],
            nidLookup[(hash >> 46) & 0x3f], nidLookup[(hash >> 40) & 0x3f],
            nidLookup[(hash >> 34) & 0x3f], nidLookup[(hash >> 28) & 0x3f],
            nidLookup[(hash >> 22) & 0x3f], nidLookup[(hash >> 16) & 0x3f],
            nidLookup[(hash >> 10) & 0x3f], nidLookup[(hash >> 4) & 0x3f],
-           nidLookup[(hash & 0xf) * 4], 0}};
+           nidLookup[(hash & 0xf) * 4], 0} };
 }
 
 std::uint64_t encodeFid(std::string_view fid);

--- a/rpcsx-os/main.cpp
+++ b/rpcsx-os/main.cpp
@@ -20,15 +20,15 @@
 #include <orbis/thread/Process.hpp>
 #include <orbis/thread/ProcessOps.hpp>
 #include <orbis/thread/Thread.hpp>
-#include "align.hpp"
 #include "amdgpu/bridge/bridge.hpp"
-#include "bridge.hpp"
-#include "io-device.hpp"
-#include "io-devices.hpp"
-#include "linker.hpp"
-#include "ops.hpp"
-#include "vfs.hpp"
-#include "vm.hpp"
+#include "rpcsx-os/align.hpp"
+#include "rpcsx-os/bridge.hpp"
+#include "rpcsx-os/io-device.hpp"
+#include "rpcsx-os/io-devices.hpp"
+#include "rpcsx-os/linker.hpp"
+#include "rpcsx-os/ops.hpp"
+#include "rpcsx-os/vfs.hpp"
+#include "rpcsx-os/vm.hpp"
 
 static int g_gpuPid;
 

--- a/rpcsx-os/ops.cpp
+++ b/rpcsx-os/ops.cpp
@@ -6,15 +6,15 @@
 #include <optional>
 #include <set>
 
-#include "ops.hpp"
-#include "io-device.hpp"
-#include "linker.hpp"
 #include "orbis/module/ModuleHandle.hpp"
 #include "orbis/thread/Process.hpp"
 #include "orbis/thread/Thread.hpp"
 #include "orbis/utils/Rc.hpp"
-#include "vfs.hpp"
-#include "vm.hpp"
+#include "rpcsx-os/ops.hpp"
+#include "rpcsx-os/io-device.hpp"
+#include "rpcsx-os/linker.hpp"
+#include "rpcsx-os/vfs.hpp"
+#include "rpcsx-os/vm.hpp"
 
 using namespace orbis;
 

--- a/rpcsx-os/ops.cpp
+++ b/rpcsx-os/ops.cpp
@@ -1,3 +1,11 @@
+#include <unistd.h>
+
+#include <cstdio>
+#include <filesystem>
+#include <map>
+#include <optional>
+#include <set>
+
 #include "ops.hpp"
 #include "io-device.hpp"
 #include "linker.hpp"
@@ -7,12 +15,6 @@
 #include "orbis/utils/Rc.hpp"
 #include "vfs.hpp"
 #include "vm.hpp"
-#include <cstdio>
-#include <filesystem>
-#include <map>
-#include <optional>
-#include <set>
-#include <unistd.h>
 
 using namespace orbis;
 
@@ -25,9 +27,10 @@ orbis::SysResult mmap(orbis::Thread *thread, orbis::caddr_t addr,
   auto result = (void *)-1;
   if (fd == -1) {
     result = rx::vm::map(addr, len, prot, flags);
-  } else {
+  }
+  else {
     Ref<IoDeviceInstance> handle =
-        static_cast<IoDeviceInstance *>(thread->tproc->fileDescriptors.get(fd));
+      static_cast<IoDeviceInstance *>(thread->tproc->fileDescriptors.get(fd));
     if (handle == nullptr) {
       return ErrorCode::BADF;
     }
@@ -240,7 +243,7 @@ orbis::SysResult ioctl(orbis::Thread *thread, orbis::sint fd, orbis::ulong com,
   std::printf("ioctl: %s\n", ioctlToString(com).c_str());
 
   Ref<IoDeviceInstance> handle =
-      static_cast<IoDeviceInstance *>(thread->tproc->fileDescriptors.get(fd));
+    static_cast<IoDeviceInstance *>(thread->tproc->fileDescriptors.get(fd));
   if (handle == nullptr) {
     return ErrorCode::BADF;
   }
@@ -258,7 +261,7 @@ orbis::SysResult ioctl(orbis::Thread *thread, orbis::sint fd, orbis::ulong com,
 orbis::SysResult write(orbis::Thread *thread, orbis::sint fd,
                        orbis::ptr<const void> data, orbis::ulong size) {
   Ref<IoDeviceInstance> handle =
-      static_cast<IoDeviceInstance *>(thread->tproc->fileDescriptors.get(fd));
+    static_cast<IoDeviceInstance *>(thread->tproc->fileDescriptors.get(fd));
   if (handle == nullptr) {
     return ErrorCode::BADF;
   }
@@ -276,7 +279,7 @@ orbis::SysResult write(orbis::Thread *thread, orbis::sint fd,
 orbis::SysResult read(orbis::Thread *thread, orbis::sint fd,
                       orbis::ptr<void> data, orbis::ulong size) {
   Ref<IoDeviceInstance> handle =
-      static_cast<IoDeviceInstance *>(thread->tproc->fileDescriptors.get(fd));
+    static_cast<IoDeviceInstance *>(thread->tproc->fileDescriptors.get(fd));
   if (handle == nullptr) {
     return ErrorCode::BADF;
   }
@@ -304,7 +307,7 @@ orbis::SysResult pwrite(orbis::Thread *thread, orbis::sint fd,
 orbis::SysResult lseek(orbis::Thread *thread, orbis::sint fd,
                        orbis::ulong offset, orbis::sint whence) {
   Ref<IoDeviceInstance> handle =
-      static_cast<IoDeviceInstance *>(thread->tproc->fileDescriptors.get(fd));
+    static_cast<IoDeviceInstance *>(thread->tproc->fileDescriptors.get(fd));
   if (handle == nullptr) {
     return ErrorCode::BADF;
   }
@@ -484,8 +487,8 @@ SysResult processNeeded(Thread *thread) {
       if (neededModule->soName != needed) {
         if (neededModule->soName[0] != '\0') {
           std::fprintf(
-              stderr, "Module name mismatch, expected '%s', loaded '%s' (%s)\n",
-              needed.c_str(), neededModule->soName, neededModule->moduleName);
+            stderr, "Module name mismatch, expected '%s', loaded '%s' (%s)\n",
+            needed.c_str(), neededModule->soName, neededModule->moduleName);
           // std::abort();
         }
 
@@ -503,23 +506,23 @@ SysResult processNeeded(Thread *thread) {
     if (!hasLoadedNeeded) {
       thread->tproc->modulesMap.walk([&loadedModules](ModuleHandle modId,
                                                       Module *module) {
-        // std::printf("Module '%s' has id %u\n", module->name,
-        // (unsigned)modId);
+                                                        // std::printf("Module '%s' has id %u\n", module->name,
+                                                        // (unsigned)modId);
 
-        module->importedModules.clear();
-        module->importedModules.reserve(module->neededModules.size());
-        for (auto mod : module->neededModules) {
-          if (auto it = loadedModules.find(mod.name);
-              it != loadedModules.end()) {
-            module->importedModules.push_back(loadedModules.at(mod.name));
-            continue;
-          }
+                                                        module->importedModules.clear();
+                                                        module->importedModules.reserve(module->neededModules.size());
+                                                        for (auto mod : module->neededModules) {
+                                                          if (auto it = loadedModules.find(mod.name);
+                                                              it != loadedModules.end()) {
+                                                            module->importedModules.push_back(loadedModules.at(mod.name));
+                                                            continue;
+                                                          }
 
-          std::fprintf(stderr, "Not found needed module '%s' for object '%s'\n",
-                       mod.name.c_str(), module->soName);
-          module->importedModules.push_back({});
-        }
-      });
+                                                          std::fprintf(stderr, "Not found needed module '%s' for object '%s'\n",
+                                                                       mod.name.c_str(), module->soName);
+                                                          module->importedModules.push_back({});
+                                                        }
+                                     });
 
       break;
     }
@@ -530,7 +533,7 @@ SysResult processNeeded(Thread *thread) {
 
 SysResult registerEhFrames(Thread *thread) {
   for (auto [id, module] : thread->tproc->modulesMap) {
-    if (module->ehFrame != nullptr) { 
+    if (module->ehFrame != nullptr) {
       __register_frame(module->ehFrame);
     }
   }

--- a/rpcsx-os/orbis-kernel-config/orbis-config.hpp
+++ b/rpcsx-os/orbis-kernel-config/orbis-config.hpp
@@ -1,11 +1,13 @@
 #pragma once
 
-#include "orbis/error.hpp"
-#include "orbis/thread/RegisterId.hpp"
-#include <cstdint>
-#include <cstring>
 #include <sys/ucontext.h>
 #include <immintrin.h>
+
+#include <cstdint>
+#include <cstring>
+
+#include "orbis/error.hpp"
+#include "orbis/thread/RegisterId.hpp"
 
 namespace orbis {
 using int8_t = std::int8_t;
@@ -29,18 +31,18 @@ using slong = int64_t;
 using ulong = uint64_t;
 
 template <typename T> using ptr = T *;
-template <typename T> using cptr = T * const;
+template <typename T> using cptr = T *const;
 
 using caddr_t = ptr<char>;
 
 inline ErrorCode uread(void *kernelAddress, ptr<const void> userAddress,
-                  size_t size) {
+                       size_t size) {
   std::memcpy(kernelAddress, userAddress, size);
   return {};
 }
 
 inline ErrorCode uwrite(ptr<void> userAddress, const void *kernelAddress,
-                   size_t size) {
+                        size_t size) {
   std::memcpy(userAddress, kernelAddress, size);
   return {};
 }

--- a/rpcsx-os/vfs.cpp
+++ b/rpcsx-os/vfs.cpp
@@ -2,8 +2,8 @@
 #include <map>
 #include <string_view>
 
-#include "vfs.hpp"
-#include "io-device.hpp"
+#include "rpcsx-os/vfs.hpp"
+#include "rpcsx-os/io-device.hpp"
 #include "orbis/error/ErrorCode.hpp"
 #include "orbis/error/SysResult.hpp"
 

--- a/rpcsx-os/vfs.cpp
+++ b/rpcsx-os/vfs.cpp
@@ -1,12 +1,11 @@
-
+#include <filesystem>
+#include <map>
+#include <string_view>
 
 #include "vfs.hpp"
 #include "io-device.hpp"
 #include "orbis/error/ErrorCode.hpp"
 #include "orbis/error/SysResult.hpp"
-#include <filesystem>
-#include <map>
-#include <string_view>
 
 static std::map<std::string, orbis::Ref<IoDevice>> sMountsMap;
 
@@ -17,7 +16,7 @@ void rx::vfs::deinitialize() {
 
 orbis::SysResult rx::vfs::mount(const std::filesystem::path &guestPath, IoDevice *dev) {
   auto [it, inserted] =
-      sMountsMap.emplace(guestPath.lexically_normal().string(), dev);
+    sMountsMap.emplace(guestPath.lexically_normal().string(), dev);
 
   if (!inserted) {
     return orbis::ErrorCode::EXIST;
@@ -27,7 +26,7 @@ orbis::SysResult rx::vfs::mount(const std::filesystem::path &guestPath, IoDevice
 }
 
 orbis::SysResult rx::vfs::open(std::string_view path, int flags, int mode,
-                           orbis::Ref<IoDeviceInstance> *instance) {
+                               orbis::Ref<IoDeviceInstance> *instance) {
   orbis::Ref<IoDevice> device;
   bool isCharacterDevice = path.starts_with("/dev/");
 
@@ -52,7 +51,7 @@ orbis::SysResult rx::vfs::open(std::string_view path, int flags, int mode,
 
   if (device != nullptr) {
     return (orbis::ErrorCode)device->open(
-        device.get(), instance, std::string(path).c_str(), flags, mode);
+      device.get(), instance, std::string(path).c_str(), flags, mode);
   }
 
   if (isCharacterDevice) {

--- a/rpcsx-os/vfs.hpp
+++ b/rpcsx-os/vfs.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
+#include <filesystem>
+
 #include "orbis/error/SysResult.hpp"
 #include "orbis/utils/Rc.hpp"
-#include <filesystem>
 
 struct IoDevice;
 struct IoDeviceInstance;

--- a/rpcsx-os/vfs.hpp
+++ b/rpcsx-os/vfs.hpp
@@ -14,4 +14,4 @@ void deinitialize();
 orbis::SysResult mount(const std::filesystem::path &guestPath, IoDevice *dev);
 orbis::SysResult open(std::string_view path, int flags, int mode,
                       orbis::Ref<IoDeviceInstance> *instance);
-} // namespace vfs
+} // namespace rx::vfs

--- a/rpcsx-os/vm.cpp
+++ b/rpcsx-os/vm.cpp
@@ -1,14 +1,16 @@
-#include "vm.hpp"
-#include "align.hpp"
-#include "bridge.hpp"
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
 #include <bit>
 #include <cassert>
 #include <cinttypes>
 #include <cstring>
-#include <fcntl.h>
 #include <map>
-#include <sys/mman.h>
-#include <unistd.h>
+
+#include "vm.hpp"
+#include "align.hpp"
+#include "bridge.hpp"
 
 namespace utils {
 namespace {
@@ -243,7 +245,7 @@ std::string rx::vm::mapProtToString(std::int32_t prot) {
 static constexpr std::uint64_t kPageMask = rx::vm::kPageSize - 1;
 static constexpr std::uint64_t kBlockShift = 32;
 static constexpr std::uint64_t kBlockSize = static_cast<std::uint64_t>(1)
-                                            << kBlockShift;
+<< kBlockShift;
 static constexpr std::uint64_t kBlockMask = kBlockSize - 1;
 static constexpr std::uint64_t kPagesInBlock = kBlockSize / rx::vm::kPageSize;
 static constexpr std::uint64_t kFirstBlock = 0x00;
@@ -253,7 +255,7 @@ static constexpr std::uint64_t kGroupSize = 64;
 static constexpr std::uint64_t kGroupMask = kGroupSize - 1;
 static constexpr std::uint64_t kGroupsInBlock = kPagesInBlock / kGroupSize;
 static constexpr std::uint64_t kMinAddress =
-    kFirstBlock * kBlockSize + rx::vm::kPageSize * 0x10;
+kFirstBlock * kBlockSize + rx::vm::kPageSize * 0x10;
 static constexpr std::uint64_t kMaxAddress = (kLastBlock + 1) * kBlockSize - 1;
 static constexpr std::uint64_t kMemorySize = kBlockCount * kBlockSize;
 
@@ -309,30 +311,30 @@ struct Block {
     std::uint64_t groupIndex = firstPage / kGroupSize;
 
     std::uint64_t addAllocatedFlags =
-        (addFlags & kAllocated) ? ~static_cast<std::uint64_t>(0) : 0;
+      (addFlags & kAllocated) ? ~static_cast<std::uint64_t>(0) : 0;
     std::uint64_t addReadableFlags =
-        (addFlags & kReadable) ? ~static_cast<std::uint64_t>(0) : 0;
+      (addFlags & kReadable) ? ~static_cast<std::uint64_t>(0) : 0;
     std::uint64_t addWritableFlags =
-        (addFlags & kWritable) ? ~static_cast<std::uint64_t>(0) : 0;
+      (addFlags & kWritable) ? ~static_cast<std::uint64_t>(0) : 0;
     std::uint64_t addExecutableFlags =
-        (addFlags & kExecutable) ? ~static_cast<std::uint64_t>(0) : 0;
+      (addFlags & kExecutable) ? ~static_cast<std::uint64_t>(0) : 0;
     std::uint64_t addGpuReadableFlags =
-        (addFlags & kGpuReadable) ? ~static_cast<std::uint64_t>(0) : 0;
+      (addFlags & kGpuReadable) ? ~static_cast<std::uint64_t>(0) : 0;
     std::uint64_t addGpuWritableFlags =
-        (addFlags & kGpuWritable) ? ~static_cast<std::uint64_t>(0) : 0;
+      (addFlags & kGpuWritable) ? ~static_cast<std::uint64_t>(0) : 0;
 
     std::uint64_t removeAllocatedFlags =
-        (removeFlags & kAllocated) ? ~static_cast<std::uint64_t>(0) : 0;
+      (removeFlags & kAllocated) ? ~static_cast<std::uint64_t>(0) : 0;
     std::uint64_t removeReadableFlags =
-        (removeFlags & kReadable) ? ~static_cast<std::uint64_t>(0) : 0;
+      (removeFlags & kReadable) ? ~static_cast<std::uint64_t>(0) : 0;
     std::uint64_t removeWritableFlags =
-        (removeFlags & kWritable) ? ~static_cast<std::uint64_t>(0) : 0;
+      (removeFlags & kWritable) ? ~static_cast<std::uint64_t>(0) : 0;
     std::uint64_t removeExecutableFlags =
-        (removeFlags & kExecutable) ? ~static_cast<std::uint64_t>(0) : 0;
+      (removeFlags & kExecutable) ? ~static_cast<std::uint64_t>(0) : 0;
     std::uint64_t removeGpuReadableFlags =
-        (removeFlags & kGpuReadable) ? ~static_cast<std::uint64_t>(0) : 0;
+      (removeFlags & kGpuReadable) ? ~static_cast<std::uint64_t>(0) : 0;
     std::uint64_t removeGpuWritableFlags =
-        (removeFlags & kGpuWritable) ? ~static_cast<std::uint64_t>(0) : 0;
+      (removeFlags & kGpuWritable) ? ~static_cast<std::uint64_t>(0) : 0;
 
     if ((firstPage & kGroupMask) != 0) {
       auto count = kGroupSize - (firstPage & kGroupMask);
@@ -347,19 +349,19 @@ struct Block {
       auto &group = groups[groupIndex++];
 
       group.allocated = (group.allocated & ~(removeAllocatedFlags & mask)) |
-                        (addAllocatedFlags & mask);
+        (addAllocatedFlags & mask);
       group.readable = (group.readable & ~(removeReadableFlags & mask)) |
-                       (addReadableFlags & mask);
+        (addReadableFlags & mask);
       group.writable = (group.writable & ~(removeWritableFlags & mask)) |
-                       (addWritableFlags & mask);
+        (addWritableFlags & mask);
       group.executable = (group.executable & ~(removeExecutableFlags & mask)) |
-                         (addExecutableFlags & mask);
+        (addExecutableFlags & mask);
       group.gpuReadable =
-          (group.gpuReadable & ~(removeGpuReadableFlags & mask)) |
-          (addGpuReadableFlags & mask);
+        (group.gpuReadable & ~(removeGpuReadableFlags & mask)) |
+        (addGpuReadableFlags & mask);
       group.gpuWritable =
-          (group.gpuWritable & ~(removeGpuWritableFlags & mask)) |
-          (addGpuWritableFlags & mask);
+        (group.gpuWritable & ~(removeGpuWritableFlags & mask)) |
+        (addGpuWritableFlags & mask);
     }
 
     while (pagesCount >= kGroupSize) {
@@ -368,17 +370,17 @@ struct Block {
       auto &group = groups[groupIndex++];
 
       group.allocated =
-          (group.allocated & ~removeAllocatedFlags) | addAllocatedFlags;
+        (group.allocated & ~removeAllocatedFlags) | addAllocatedFlags;
       group.readable =
-          (group.readable & ~removeReadableFlags) | addReadableFlags;
+        (group.readable & ~removeReadableFlags) | addReadableFlags;
       group.writable =
-          (group.writable & ~removeWritableFlags) | addWritableFlags;
+        (group.writable & ~removeWritableFlags) | addWritableFlags;
       group.executable =
-          (group.executable & ~removeExecutableFlags) | addExecutableFlags;
+        (group.executable & ~removeExecutableFlags) | addExecutableFlags;
       group.gpuReadable =
-          (group.gpuReadable & ~removeGpuReadableFlags) | addGpuReadableFlags;
+        (group.gpuReadable & ~removeGpuReadableFlags) | addGpuReadableFlags;
       group.gpuWritable =
-          (group.gpuWritable & ~removeGpuWritableFlags) | addGpuWritableFlags;
+        (group.gpuWritable & ~removeGpuWritableFlags) | addGpuWritableFlags;
     }
 
     if (pagesCount > 0) {
@@ -386,19 +388,19 @@ struct Block {
       auto &group = groups[groupIndex++];
 
       group.allocated = (group.allocated & ~(removeAllocatedFlags & mask)) |
-                        (addAllocatedFlags & mask);
+        (addAllocatedFlags & mask);
       group.readable = (group.readable & ~(removeReadableFlags & mask)) |
-                       (addReadableFlags & mask);
+        (addReadableFlags & mask);
       group.writable = (group.writable & ~(removeWritableFlags & mask)) |
-                       (addWritableFlags & mask);
+        (addWritableFlags & mask);
       group.executable = (group.executable & ~(removeExecutableFlags & mask)) |
-                         (addExecutableFlags & mask);
+        (addExecutableFlags & mask);
       group.gpuReadable =
-          (group.gpuReadable & ~(removeGpuReadableFlags & mask)) |
-          (addGpuReadableFlags & mask);
+        (group.gpuReadable & ~(removeGpuReadableFlags & mask)) |
+        (addGpuReadableFlags & mask);
       group.gpuWritable =
-          (group.gpuWritable & ~(removeGpuWritableFlags & mask)) |
-          (addGpuWritableFlags & mask);
+        (group.gpuWritable & ~(removeGpuWritableFlags & mask)) |
+        (addGpuWritableFlags & mask);
     }
   }
 
@@ -499,14 +501,14 @@ struct Block {
               if (freeCount >= count ||
                   (freeCount > 0 && processedPages >= kGroupSize)) {
                 foundPage =
-                    groupIndex * kGroupSize + processedPages - freeCount;
+                  groupIndex * kGroupSize + processedPages - freeCount;
                 foundCount = freeCount;
                 break;
               }
 
               while (auto usedCount = std::countr_one(tmpAllocatedBits)) {
                 auto nextProcessedPages =
-                    utils::alignUp(processedPages + usedCount, groupAlignment);
+                  utils::alignUp(processedPages + usedCount, groupAlignment);
                 if (nextProcessedPages - processedPages >= 64) {
                   tmpAllocatedBits = 0;
                 } else {
@@ -520,9 +522,9 @@ struct Block {
             // searching on next iterations
             auto freeCount = std::countl_zero(allocatedBits);
             auto alignedPageIndex =
-                utils::alignUp(kGroupSize - freeCount, groupAlignment);
+              utils::alignUp(kGroupSize - freeCount, groupAlignment);
             freeCount =
-                kGroupSize - alignedPageIndex; // calc aligned free pages
+              kGroupSize - alignedPageIndex; // calc aligned free pages
 
             foundCount = freeCount;
             foundPage = groupIndex * kGroupSize + alignedPageIndex;
@@ -531,7 +533,7 @@ struct Block {
       }
     } else {
       std::uint64_t blockAlignment =
-          alignment / (kGroupSize * rx::vm::kPageSize);
+        alignment / (kGroupSize * rx::vm::kPageSize);
 
       for (std::uint64_t groupIndex = 0;
            groupIndex < kGroupsInBlock && foundCount < count; ++groupIndex) {
@@ -579,7 +581,7 @@ struct Block {
 static Block gBlocks[kBlockCount];
 
 static std::map<std::uint64_t, rx::vm::VirtualQueryInfo, std::greater<>>
-    gVirtualAllocations;
+gVirtualAllocations;
 
 static void reserve(std::uint64_t startAddress, std::uint64_t endAddress) {
   auto blockIndex = startAddress >> kBlockShift;
@@ -589,7 +591,7 @@ static void reserve(std::uint64_t startAddress, std::uint64_t endAddress) {
 
   auto firstPage = (startAddress & kBlockMask) >> rx::vm::kPageShift;
   auto pagesCount =
-      (endAddress - startAddress + (rx::vm::kPageSize - 1)) >> rx::vm::kPageShift;
+    (endAddress - startAddress + (rx::vm::kPageSize - 1)) >> rx::vm::kPageShift;
 
   gBlocks[blockIndex - kFirstBlock].setFlags(firstPage, pagesCount, kAllocated);
 }
@@ -630,7 +632,7 @@ void rx::vm::deinitialize() {
 constexpr auto kPhysicalMemorySize = 5568ull * 1024 * 1024;
 constexpr auto kFlexibleMemorySize = 448ull * 1024 * 1024;
 constexpr auto kMainDirectMemorySize =
-    kPhysicalMemorySize - kFlexibleMemorySize;
+kPhysicalMemorySize - kFlexibleMemorySize;
 
 /*
 std::uint64_t allocate(std::uint64_t phyAddress, std::uint64_t size,
@@ -723,7 +725,7 @@ void *rx::vm::map(void *addr, std::uint64_t len, std::int32_t prot,
     for (auto blockIndex = hitBlockIndex; blockIndex <= kLastBlock;
          ++blockIndex) {
       auto pageAddress = gBlocks[blockIndex - kFirstBlock].findFreePages(
-          pagesCount, alignment);
+        pagesCount, alignment);
 
       if (pageAddress != kBadAddress) {
         address = (pageAddress << kPageShift) | (blockIndex * kBlockSize);
@@ -738,7 +740,7 @@ void *rx::vm::map(void *addr, std::uint64_t len, std::int32_t prot,
     std::size_t blockIndex = 0; // system managed block
 
     auto pageAddress =
-        gBlocks[blockIndex - kFirstBlock].findFreePages(pagesCount, alignment);
+      gBlocks[blockIndex - kFirstBlock].findFreePages(pagesCount, alignment);
 
     if (pageAddress != kBadAddress) {
       address = (pageAddress << kPageShift) | (blockIndex * kBlockSize);
@@ -765,8 +767,8 @@ void *rx::vm::map(void *addr, std::uint64_t len, std::int32_t prot,
   }
 
   gBlocks[(address >> kBlockShift) - kFirstBlock].setFlags(
-      (address & kBlockMask) >> kPageShift, pagesCount,
-      (flags & (kMapProtCpuAll | kMapProtGpuAll)) | kAllocated);
+    (address & kBlockMask) >> kPageShift, pagesCount,
+    (flags & (kMapProtCpuAll | kMapProtGpuAll)) | kAllocated);
 
   int realFlags = MAP_FIXED | MAP_SHARED;
   bool isAnon = (flags & kMapFlagAnonymous) == kMapFlagAnonymous;
@@ -800,8 +802,8 @@ void *rx::vm::map(void *addr, std::uint64_t len, std::int32_t prot,
   }
 
   auto result =
-      utils::map(reinterpret_cast<void *>(address), len, prot & kMapProtCpuAll,
-                 realFlags, gMemoryShm, address - kMinAddress);
+    utils::map(reinterpret_cast<void *>(address), len, prot & kMapProtCpuAll,
+               realFlags, gMemoryShm, address - kMinAddress);
 
   if (result != MAP_FAILED && isAnon) {
     bool needReprotect = (prot & PROT_WRITE) == 0;
@@ -835,13 +837,13 @@ bool rx::vm::unmap(void *addr, std::uint64_t size) {
 
   if ((address >> kBlockShift) != ((address + size - 1) >> kBlockShift)) {
     std::printf(
-        "Memory error: unmap cross block range. address 0x%lx, size=0x%lx\n",
-        address, size);
+      "Memory error: unmap cross block range. address 0x%lx, size=0x%lx\n",
+      address, size);
     __builtin_trap();
   }
 
   gBlocks[(address >> kBlockShift) - kFirstBlock].removeFlags(
-      (address & kBlockMask) >> kPageShift, pages, ~0);
+    (address & kBlockMask) >> kPageShift, pages, ~0);
   rx::bridge.sendMemoryProtect(reinterpret_cast<std::uint64_t>(addr), size, 0);
   return utils::unmap(addr, size);
 }
@@ -869,8 +871,8 @@ bool rx::vm::protect(void *addr, std::uint64_t size, std::int32_t prot) {
   }
 
   gBlocks[(address >> kBlockShift) - kFirstBlock].setFlags(
-      (address & kBlockMask) >> kPageShift, pages,
-      kAllocated | (prot & (kMapProtCpuAll | kMapProtGpuAll)));
+    (address & kBlockMask) >> kPageShift, pages,
+    kAllocated | (prot & (kMapProtCpuAll | kMapProtGpuAll)));
 
   rx::bridge.sendMemoryProtect(reinterpret_cast<std::uint64_t>(addr), size, prot);
   return ::mprotect(addr, size, prot & kMapProtCpuAll) == 0;

--- a/rpcsx-os/vm.cpp
+++ b/rpcsx-os/vm.cpp
@@ -8,9 +8,9 @@
 #include <cstring>
 #include <map>
 
-#include "vm.hpp"
-#include "align.hpp"
-#include "bridge.hpp"
+#include "rpcsx-os/vm.hpp"
+#include "rpcsx-os/align.hpp"
+#include "rpcsx-os/bridge.hpp"
 
 namespace utils {
 namespace {

--- a/rpcsx-os/vm.hpp
+++ b/rpcsx-os/vm.hpp
@@ -6,7 +6,7 @@
 namespace rx::vm {
 static constexpr std::uint64_t kPageShift = 14;
 static constexpr std::uint64_t kPageSize = static_cast<std::uint64_t>(1)
-                                           << kPageShift;
+<< kPageShift;
 
 enum BlockFlags {
   kBlockFlagFlexibleMemory = 1 << 0,

--- a/rpcsx-os/vm.hpp
+++ b/rpcsx-os/vm.hpp
@@ -75,4 +75,4 @@ bool protect(void *addr, std::uint64_t size, std::int32_t prot);
 bool virtualQuery(const void *addr, std::int32_t flags, VirtualQueryInfo *info);
 bool queryProtection(const void *addr, std::uint64_t *startAddress,
                      std::uint64_t *endAddress, std::int64_t *prot);
-}
+} // namespace rx::vm


### PR DESCRIPTION
This PR adds the linter, cpplint. I have disabled some of the more controversial or unnecessary rules.

Each file has also been formatted by the Visual Studio C++ Formating Engine. The following settings were adjusted to match the existing common style throughout the project:

- Namespace Contents Indentation: Disabled
- Within Paranthesis Indentation: Align To Parenthesis
- Before Else New Line: Disabled
- Open Brace Position Block: Same Line
- Open Brace Position Function: Same Line
- Open Brace Position Lambda: Same Line
- Open Brace Position Namespace: Same Line
- Open Brace Position Type: Same Line
- Pointer Reference Alignment: Right