### PR TITLE
Find packages and sane include dirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ project(rpcsx)
 
 set(CMAKE_CXX_EXTENSIONS off)
 set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_subdirectory(3rdparty/crypto)
 add_subdirectory(orbis-kernel)

--- a/orbis-kernel/CMakeLists.txt
+++ b/orbis-kernel/CMakeLists.txt
@@ -65,11 +65,11 @@ add_library(obj.orbis-kernel OBJECT
 target_link_libraries(obj.orbis-kernel PUBLIC orbis::kernel::config)
 
 target_include_directories(obj.orbis-kernel
-PUBLIC
-  include
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
 
-PRIVATE
-  include/orbis
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include/orbis
 )
 
 add_library(orbis-kernel STATIC)

--- a/rpcsx-gpu/CMakeLists.txt
+++ b/rpcsx-gpu/CMakeLists.txt
@@ -1,9 +1,11 @@
+find_package(Vulkan 1.3 REQUIRED)
+find_package(glfw3 3.3 REQUIRED)
 
 add_executable(rpcsx-gpu
   main.cpp
 )
 
-target_include_directories(rpcsx-gpu PUBLIC .)
-target_link_libraries(rpcsx-gpu PUBLIC amdgpu::bridge amdgpu::device glfw vulkan)
+target_include_directories(rpcsx-gpu PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(rpcsx-gpu PUBLIC amdgpu::bridge amdgpu::device glfw Vulkan::Vulkan)
 set_target_properties(rpcsx-gpu PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 install(TARGETS rpcsx-gpu RUNTIME DESTINATION bin)

--- a/rpcsx-os/CMakeLists.txt
+++ b/rpcsx-os/CMakeLists.txt
@@ -27,7 +27,8 @@ add_executable(rpcsx-os
   io-device.cpp
   vfs.cpp
 )
-target_include_directories(rpcsx-os PUBLIC .)
+
+target_include_directories(rpcsx-os PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(rpcsx-os PUBLIC orbis::kernel amdgpu::bridge libcrypto unwind unwind-x86_64)
 target_link_options(rpcsx-os PUBLIC "LINKER:-Ttext-segment,0x0000010000000000")
 target_compile_options(rpcsx-os PRIVATE "-march=native")


### PR DESCRIPTION
- Enforce CXX Standard
 - use Find_package to find `Vulkan` and `glfw3`
 - targets include their `cmake_current_source_dir`  in place of `.`