### PR TITLE
Resolve compilation warnings

### DIFF
--- a/hw/amdgpu/bridge/include/amdgpu/bridge/bridge.hpp
+++ b/hw/amdgpu/bridge/include/amdgpu/bridge/bridge.hpp
@@ -89,7 +89,9 @@ struct BridgePusher {
     header->vmAddress = address;
     header->vmSize = size;
     std::strncpy(header->vmName, name, sizeof(header->vmName));
-    header->flags |= static_cast<std::uint64_t>(BridgeFlags::VmConfigured);
+    std::uint64_t temp = header->flags;
+    temp |= static_cast<std::uint64_t>(BridgeFlags::VmConfigured);
+    header->flags = temp;
   }
 
   void sendMemoryProtect(std::uint64_t address, std::uint64_t size,

--- a/rpcsx-os/orbis-kernel-config/orbis-config.hpp
+++ b/rpcsx-os/orbis-kernel-config/orbis-config.hpp
@@ -103,6 +103,8 @@ inline uint64_t readRegister(void *context, RegisterId id) {
     return c->gregs[REG_RSP];
   case RegisterId::rflags:
     return c->gregs[REG_EFL];
+  default:
+    return 0;
   }
 }
 


### PR DESCRIPTION
Hi!
I'm new in the project, still figuring out on how I can contribute.
I found some warnings during compilation and I'm opening this PR to discuss and resolve them.
Would love to have some feedback

1x No default value (`orbis::uint64_t orbis::readRegister(void*, orbis::RegisterId)`)
![image](https://github.com/RPCSX/rpcsx/assets/3681977/2d1a49be-2ff4-4044-a807-2c86fa9f341d)

8x Compound assignment (`void amdgpu::bridge::BridgePusher::setVm(uint64_t, uint64_t, const char*)`)
![image](https://github.com/RPCSX/rpcsx/assets/3681977/05e956c9-9985-429b-b4cf-d7dc5376106c)
