### PR TITLE
orbis-kernel: fix linking

### DIFF
--- a/orbis-kernel/CMakeLists.txt
+++ b/orbis-kernel/CMakeLists.txt
@@ -68,7 +68,7 @@ add_library(obj.orbis-kernel OBJECT
   src/utils/Logs.cpp
 )
 
-target_link_libraries(obj.orbis-kernel PUBLIC orbis::kernel::config obj.orbis-utils-ipc)
+target_link_libraries(obj.orbis-kernel PUBLIC orbis::kernel::config $<TARGET_OBJECTS:obj.orbis-utils-ipc>)
 
 target_include_directories(obj.orbis-kernel
     PUBLIC


### PR DESCRIPTION
Fix undefined references (since https://github.com/RPCSX/rpcsx/commit/450fd30889b43a55cfb9355948ef56b272ba7144) when linking with `-Wl,-z,defs` in `LDFLAGS`.

`orbis-kernel-shared` does not seem to be used anywhere by the way.