### PR TITLE
[amdgpu] libspirv: Fix pushRegion

### DIFF
--- a/hw/amdgpu/lib/libspirv/include/spirv/spirv-builder.hpp
+++ b/hw/amdgpu/lib/libspirv/include/spirv/spirv-builder.hpp
@@ -344,11 +344,11 @@ public:
     std::memcpy(mData.data() + offset, other.data(),
                 other.size() * sizeof(std::uint32_t));
 
-    for (auto &[id, def] : mIdDefs) {
+    for (auto &[id, def] : other.mIdDefs) {
       mIdDefs[id] = offset + def;
     }
 
-    for (auto &[id, uses] : mIdUses) {
+    for (auto &[id, uses] : other.mIdUses) {
       auto &idUses = mIdUses[id];
       idUses.reserve(idUses.size() + uses.size());
 


### PR DESCRIPTION
Fix an issue with the pushRegion function, which modifies/duplicates (in a way that leads to undefined behavior) the id definitions and uses of its own fields instead of adding the ones from the other region.