### PR TITLE
Add SceAvSetting for higher firmware versions

### DIFF
--- a/rpcsx-os/iodev/shm.cpp
+++ b/rpcsx-os/iodev/shm.cpp
@@ -40,6 +40,9 @@ orbis::ErrorCode ShmDevice::open(orbis::Ref<orbis::File> *file,
     } else if (name == "/rpcsx-SceNpPlusLogger") {
       realFlags |= O_CREAT;
       size = 0x4400;
+    } else if (name == "/rpcsx-SceAvSetting") {
+      realFlags |= O_CREAT;
+      size = 0x4400;
     } else {
       ORBIS_LOG_ERROR("SHM: unknown shared memory", path);
       thread->where();


### PR DESCRIPTION
This allows the emulator to work on samples and Sonic Mania on a firmware version higher than 5.05.

Not sure if this is the right thing to do in long term, but thought might share a quick fix.