### PR TITLE
Fixing fedora 

### DIFF
--- a/rpcsx-os/CMakeLists.txt
+++ b/rpcsx-os/CMakeLists.txt
@@ -33,7 +33,7 @@ add_executable(rpcsx-os
 
 target_include_directories(rpcsx-os PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(rpcsx-os PUBLIC orbis::kernel amdgpu::bridge libcrypto unwind unwind-x86_64 xbyak)
-target_link_options(rpcsx-os PUBLIC "LINKER:-Ttext-segment,0x0000010000000000")
+target_link_options(rpcsx-os PUBLIC "LINKER:-Ttext-segment,0x0000000010000000")
 target_compile_options(rpcsx-os PRIVATE "-march=native")
 
 set_target_properties(rpcsx-os PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)


### PR DESCRIPTION
This change fixes a compile issue with cmake on fedora 38 

here was the error 
![image](https://github.com/RPCSX/rpcsx/assets/84041391/3cfae895-c28c-40b3-a7d6-a2e1ee7c2f4e)
