### PR TITLE
cmake: fix sox linking

### DIFF
--- a/orbis-kernel/CMakeLists.txt
+++ b/orbis-kernel/CMakeLists.txt
@@ -68,7 +68,7 @@ add_library(obj.orbis-kernel OBJECT
   src/utils/Logs.cpp
 )
 
-target_link_libraries(obj.orbis-kernel PUBLIC orbis::kernel::config $<TARGET_OBJECTS:obj.orbis-utils-ipc>)
+target_link_libraries(obj.orbis-kernel PUBLIC orbis::kernel::config $<TARGET_OBJECTS:obj.orbis-utils-ipc> sox)
 
 target_include_directories(obj.orbis-kernel
     PUBLIC

--- a/rpcsx-os/CMakeLists.txt
+++ b/rpcsx-os/CMakeLists.txt
@@ -32,7 +32,7 @@ add_executable(rpcsx-os
 )
 
 target_include_directories(rpcsx-os PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(rpcsx-os PUBLIC orbis::kernel amdgpu::bridge libcrypto unwind unwind-x86_64 xbyak sox)
+target_link_libraries(rpcsx-os PUBLIC orbis::kernel amdgpu::bridge libcrypto unwind unwind-x86_64 xbyak)
 target_link_options(rpcsx-os PUBLIC "LINKER:-Ttext-segment,0x0000010000000000")
 target_compile_options(rpcsx-os PRIVATE "-march=native")
 


### PR DESCRIPTION
`sox` is used in `orbis::kernel` not in `rpcsx-os`. Fix undefined references when linking with `-Wl,-z,defs` in `LDFLAGS`.