### PR TITLE
AudioOut: relatively correct parsing

### DIFF
--- a/orbis-kernel/src/sys/sys_sce.cpp
+++ b/orbis-kernel/src/sys/sys_sce.cpp
@@ -1234,8 +1234,8 @@ orbis::SysResult orbis::sys_ipmimgr_call(Thread *thread, uint op, uint kid,
         }
       } else if (syncCallParams.method == 0x12340002) { // something like open
         struct SceSysAudioSystemIpcSomethingMethodArgs {
-          uint32_t arg1;
-          uint32_t arg2;
+          uint32_t audioPort;
+          uint32_t channelId;
         };
 
         static_assert(sizeof(SceSysAudioSystemIpcSomethingMethodArgs) == 0x8);
@@ -1249,12 +1249,30 @@ orbis::SysResult orbis::sys_ipmimgr_call(Thread *thread, uint op, uint kid,
               ptr<SceSysAudioSystemIpcSomethingMethodArgs>(dataInfo.data));
 
         ORBIS_LOG_TODO("impi: SceSysAudioSystemIpcSomethingMethodArgs",
-                       args.arg1, args.arg2);
+                       args.audioPort, args.channelId);
 
         if (auto audioOut = g_context.audioOut) {
           // here startToListen
           audioOut->start();
         }
+      } else if (syncCallParams.method == 0x12340006) { // close port
+        struct SceSysAudioSystemIpcCloseAudioMethodArgs {
+          uint32_t audioPort;
+          uint32_t channelId;
+        };
+
+        static_assert(sizeof(SceSysAudioSystemIpcCloseAudioMethodArgs) == 0x8);
+
+        if (dataInfo.size != sizeof(SceSysAudioSystemIpcCloseAudioMethodArgs)) {
+          return ErrorCode::INVAL;
+        }
+
+        SceSysAudioSystemIpcCloseAudioMethodArgs args;
+        uread(args,
+              ptr<SceSysAudioSystemIpcCloseAudioMethodArgs>(dataInfo.data));
+
+        ORBIS_LOG_TODO("impi: SceSysAudioSystemIpcCloseAudioMethodArgs",
+                       args.audioPort, args.channelId);
       }
     }
 


### PR DESCRIPTION
This PR presents a more proper parsing of Control Shared Memory
- It uses a specific offset (which does not seem to change from firmware to firmware) that can be used to accurately retrieve the structure of a specific port unlike the previous implementation by searching for the first non-empty byte.
- Used mutex to wait for device initialization via sox, without it application crashed due to simultaneous initialization
- Added the last two unknown 8-channel S16 and F32 formats with postfix `_STD`, testing showed that they sound the same as normal S16 and F32 formats.

Since the sample of applications was not large, the test was performed on two games with one output and on a custom homebrew sample with three outputs, no problems were noticed and in addition `--trace` no longer crashes the application.