### PR TITLE
[rx] cmake: fix git detection

### DIFF
--- a/rx/CMakeLists.txt
+++ b/rx/CMakeLists.txt
@@ -11,17 +11,20 @@ target_include_directories(${PROJECT_NAME} PUBLIC include)
 execute_process(COMMAND date +%+4Y%m%d OUTPUT_VARIABLE RAW_VERSION)
 string(STRIP "${RAW_VERSION}" RAW_VERSION)
 
-execute_process(COMMAND git log --date=format:%Y%m%d --pretty=format:'%cd' -n 1 OUTPUT_VARIABLE GIT_DATE)
+execute_process(COMMAND git log --date=format:%Y%m%d --pretty=format:'%cd' -n 1 WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" OUTPUT_VARIABLE GIT_DATE)
 
 execute_process(COMMAND git log --pretty=format:'%h' -n 1
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     OUTPUT_VARIABLE GIT_REV)
 
 execute_process(
     COMMAND git diff --quiet --exit-code
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     RESULT_VARIABLE GIT_DIRTY ERROR_QUIET)
 
 execute_process(
     COMMAND git rev-parse --abbrev-ref HEAD
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     OUTPUT_VARIABLE GIT_BRANCH)
 
 string(SUBSTRING ${GIT_DATE} 1 8 GIT_DATE)


### PR DESCRIPTION
Fix git detection when `cmake` is not executed from within the source directory, i.e. `cmake -S path/to/src -B path/to/build`.