### PR TITLE
Remove 2nd instructions for arch. Make warning stand out

### DIFF
--- a/.github/BUILDING.md
+++ b/.github/BUILDING.md
@@ -26,14 +26,13 @@ sudo pacman -S --needed git base-devel && git clone https://aur.archlinux.org/ya
 ```
 yay -S spirv-cross
 ```
-## Getting spriv-cross on Fedora and Arch Linux
+## Getting spriv-cross on Fedora
 
 ```
 git clone https://github.com/KhronosGroup/SPIRV-Cross && cd SPIRV-Cross && mkdir build && cd build && cmake .. && cmake --build . && sudo make install
 ```
-> **Warning** <br/>
+> [!WARNING]
 > Fedora will compile to a point and then error out
-> Arch will have to use xbyak from the aur for now
 
 ## Cloning the Repo
 


### PR DESCRIPTION
This removes the second way for arch to install spriv-cross as its easier / better to just use YAY.  

This also fixes the warning to make it an actual warning and stand out a bit more.