### PR TITLE
infra: update workflows

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -24,4 +24,4 @@ jobs:
       uses: jidicula/clang-format-action@v4.13.0
       with:
         exclude-regex: (libspirv|3rdparty)
-        clang-format-version: 16
+        clang-format-version: 18

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Run clang-format
-      uses: jidicula/clang-format-action@v4.11.0
+      uses: jidicula/clang-format-action@v4.13.0
       with:
         exclude-regex: (libspirv|3rdparty)
         clang-format-version: 16

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
       uses: ZedThree/clang-tidy-review@v0.19.0
       id: review
       with:
-        clang_tidy_version: 16
+        clang_tidy_version: 18
         apt_packages: libunwind-dev, libglfw3-dev, libvulkan-dev, vulkan-validationlayers-dev, spirv-tools, glslang-tools, libspirv-cross-c-shared-dev
         cmake_command: cmake . -DCMAKE_EXPORT_COMPILE_COMMANDS=on
         split_workflow: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
       id: review
       with:
         clang_tidy_version: 18
-        apt_packages: libunwind-dev, libglfw3-dev, libvulkan-dev, vulkan-validationlayers-dev, spirv-tools, glslang-tools, libspirv-cross-c-shared-dev
+        apt_packages: libunwind-dev, libglfw3-dev, libvulkan-dev, vulkan-validationlayers, spirv-tools, glslang-tools, libspirv-cross-c-shared-dev
         cmake_command: cmake . -DCMAKE_EXPORT_COMPILE_COMMANDS=on
         split_workflow: true
     - name: Upload review

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,11 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: recursive
     - name: Run clang-tidy
-      uses: ZedThree/clang-tidy-review@v0.14.0
+      uses: ZedThree/clang-tidy-review@v0.19.0
       id: review
       with:
         clang_tidy_version: 16
@@ -19,5 +19,5 @@ jobs:
         cmake_command: cmake . -DCMAKE_EXPORT_COMPILE_COMMANDS=on
         split_workflow: true
     - name: Upload review
-      uses: ZedThree/clang-tidy-review/upload@v0.14.0
+      uses: ZedThree/clang-tidy-review/upload@v0.19.0
       id: upload-review

--- a/.github/workflows/rpcsx.yml
+++ b/.github/workflows/rpcsx.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: recursive
 
@@ -42,7 +42,7 @@ jobs:
         cmake --build build -j4
 
     - name: Upload RPCSX
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: rpcsx-bin
         path: build/bin/*

--- a/.github/workflows/tidy-comments.yml
+++ b/.github/workflows/tidy-comments.yml
@@ -8,6 +8,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: ZedThree/clang-tidy-review/post@v0.12.0
+      - uses: ZedThree/clang-tidy-review/post@v0.19.0
         with:
           lgtm_comment_body: "No linting issues found!"


### PR DESCRIPTION
Updates actions to newer versions, which should resolve deprecation warnings.

`clang-tidy` and `clang-format` have also been updated to 18.