### PR TITLE
cmake: fix link with lld and mold

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,14 @@ function(add_precompiled_vulkan_spirv target)
     endforeach()
 endfunction()
 
+function(target_base_address target address)
+    if(CMAKE_CXX_COMPILER_LINKER_ID MATCHES "^(LLD|MOLD)$")
+        target_link_options(${target} PUBLIC "LINKER:--image-base=${address}")
+    else()
+        target_link_options(${target} PUBLIC "LINKER:-Ttext-segment,${address}")
+    endif()
+endfunction()
+
 add_subdirectory(tools)
 
 add_subdirectory(orbis-kernel)

--- a/rpcsx-gpu/CMakeLists.txt
+++ b/rpcsx-gpu/CMakeLists.txt
@@ -8,5 +8,5 @@ add_executable(rpcsx-gpu
 target_include_directories(rpcsx-gpu PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(rpcsx-gpu PUBLIC amdgpu::bridge amdgpu::device glfw Vulkan::Vulkan rx)
 set_target_properties(rpcsx-gpu PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
-target_link_options(rpcsx-os PUBLIC "LINKER:-Ttext-segment,0x0000060000000000")
+target_base_address(rpcsx-os 0x0000060000000000)
 install(TARGETS rpcsx-gpu RUNTIME DESTINATION bin)

--- a/rpcsx-os/CMakeLists.txt
+++ b/rpcsx-os/CMakeLists.txt
@@ -65,7 +65,7 @@ add_executable(rpcsx-os
 
 target_include_directories(rpcsx-os PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(rpcsx-os PUBLIC orbis::kernel amdgpu::bridge rx libcrypto libunwind::unwind-x86_64 xbyak::xbyak)
-target_link_options(rpcsx-os PUBLIC "LINKER:-Ttext-segment,0x0000010000000000")
+target_base_address(rpcsx-os 0x0000010000000000)
 target_compile_options(rpcsx-os PRIVATE "-mfsgsbase")
 
 set_target_properties(rpcsx-os PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)


### PR DESCRIPTION
`-Ttext-segment` is only supported by `bfd`/`gold`.
The ([possibly](https://github.com/rui314/mold/issues/871)?) equivalent `--image-base` is supported by `bfd`, `lld` and `mold`. 