### PR TITLE
cmake: use ALSA imported target

### DIFF
--- a/rpcsx-os/CMakeLists.txt
+++ b/rpcsx-os/CMakeLists.txt
@@ -1,5 +1,6 @@
 find_package(libunwind REQUIRED)
 find_package(sox REQUIRED)
+find_package(ALSA REQUIRED)
 
 add_library(standalone-config INTERFACE)
 target_include_directories(standalone-config INTERFACE orbis-kernel-config)
@@ -69,7 +70,7 @@ add_executable(rpcsx-os
 )
 
 target_include_directories(rpcsx-os PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(rpcsx-os PUBLIC orbis::kernel amdgpu::bridge rx libcrypto libunwind::unwind-x86_64 xbyak::xbyak sox::sox asound)
+target_link_libraries(rpcsx-os PUBLIC orbis::kernel amdgpu::bridge rx libcrypto libunwind::unwind-x86_64 xbyak::xbyak sox::sox ALSA::ALSA)
 target_base_address(rpcsx-os 0x0000010000000000)
 target_compile_options(rpcsx-os PRIVATE "-mfsgsbase")
 


### PR DESCRIPTION
Use the internal [FindALSA](https://cmake.org/cmake/help/latest/module/FindALSA.html) module.