### PR TITLE
orbis-kernel: Define umtx ops in header

### DIFF
--- a/orbis-kernel/include/orbis/umtx.hpp
+++ b/orbis-kernel/include/orbis/umtx.hpp
@@ -29,6 +29,30 @@ inline constexpr auto kCvWaitCheckUnparking = 0x01;
 inline constexpr auto kCvWaitAbsTime = 0x02;
 inline constexpr auto kCvWaitClockId = 0x04;
 
+inline constexpr auto kUmtxOpLock = 0;
+inline constexpr auto kUmtxOpUnlock = 1;
+inline constexpr auto kUmtxOpWait = 2;
+inline constexpr auto kUmtxOpWake = 3;
+inline constexpr auto kUmtxOpMutexTrylock = 4;
+inline constexpr auto kUmtxOpMutexLock = 5;
+inline constexpr auto kUmtxOpMutexUnock = 6;
+inline constexpr auto kUmtxOpSetCeiling = 7;
+inline constexpr auto kUmtxOpCvWait = 8;
+inline constexpr auto kUmtxOpCvSignal = 9;
+inline constexpr auto kUmtxOpCvBroadcast = 10;
+inline constexpr auto kUmtxOpWaitUint = 11;
+inline constexpr auto kUmtxOpRwRdLock = 12;
+inline constexpr auto kUmtxOpRwWrLock = 13;
+inline constexpr auto kUmtxOpRwUnlock = 14;
+inline constexpr auto kUmtxOpWaitUintPrivate = 15;
+inline constexpr auto kUmtxOpWakePrivate = 16;
+inline constexpr auto kUmtxOpMutexWait = 17;
+inline constexpr auto kUmtxOpMutexWake = 18;
+inline constexpr auto kUmtxOpSemWait = 19;
+inline constexpr auto kUmtxOpSemWake = 20;
+inline constexpr auto kUmtxOpNwakePrivate = 21;
+inline constexpr auto kUmtxOpMutexWake2 = 22;
+
 inline constexpr auto kSemNamed = 2;
 
 struct umtx {

--- a/orbis-kernel/src/sys/sys_umtx.cpp
+++ b/orbis-kernel/src/sys/sys_umtx.cpp
@@ -84,36 +84,35 @@ orbis::SysResult orbis::sys__umtx_op(Thread *thread, ptr<void> obj, sint op,
   };
 
   switch (op) {
-  case 0: {
+  case kUmtxOpLock: {
     return with_timeout([&](std::uint64_t ut) {
       return umtx_lock_umtx(thread, (ptr<umtx>)obj, val, ut);
     });
   }
-  case 1:
+  case kUmtxOpUnlock:
     return umtx_unlock_umtx(thread, (ptr<umtx>)obj, val);
-  case 2: {
+  case kUmtxOpWait: {
     return with_timeout(
         [&](std::uint64_t ut) {
           return umtx_wait(thread, obj, val, ut, false, true);
         },
         false);
   }
-  case 3:
+  case kUmtxOpWake:
     return umtx_wake(thread, obj, val);
-  case 4:
+  case kUmtxOpMutexTrylock:
     return umtx_trylock_umutex(thread, (ptr<umutex>)obj);
-  case 5: {
+  case kUmtxOpMutexLock: {
     return with_timeout([&](std::uint64_t ut) {
       return umtx_lock_umutex(thread, (ptr<umutex>)obj, ut);
     });
   }
-  case 6:
+  case kUmtxOpMutexUnock:
     return umtx_unlock_umutex(thread, (ptr<umutex>)obj);
-  case 7:
+  case kUmtxOpSetCeiling:
     return umtx_set_ceiling(thread, (ptr<umutex>)obj, val,
                             (ptr<uint32_t>)uaddr1);
-
-  case 8: {
+  case kUmtxOpCvWait: {
     return with_timeout(
         [&](std::uint64_t ut) {
           return umtx_cv_wait(thread, (ptr<ucond>)obj, (ptr<umutex>)uaddr1, ut,
@@ -121,55 +120,54 @@ orbis::SysResult orbis::sys__umtx_op(Thread *thread, ptr<void> obj, sint op,
         },
         false);
   }
-
-  case 9:
+  case kUmtxOpCvSignal:
     return umtx_cv_signal(thread, (ptr<ucond>)obj);
-  case 10:
+  case kUmtxOpCvBroadcast:
     return umtx_cv_broadcast(thread, (ptr<ucond>)obj);
-  case 11: {
+  case kUmtxOpWaitUint: {
     return with_timeout(
         [&](std::uint64_t ut) {
           return umtx_wait(thread, obj, val, ut, true, true);
         },
         false);
   }
-  case 12:
+  case kUmtxOpRwRdLock:
     return with_timeout([&](std::uint64_t ut) {
       return umtx_rw_rdlock(thread, (ptr<urwlock>)obj, val, ut);
     });
-  case 13:
+  case kUmtxOpRwWrLock:
     return with_timeout([&](std::uint64_t ut) {
       return umtx_rw_wrlock(thread, (ptr<urwlock>)obj, ut);
     });
-  case 14:
+  case kUmtxOpRwUnlock:
     return umtx_rw_unlock(thread, (ptr<urwlock>)obj);
-  case 15: {
+  case kUmtxOpWaitUintPrivate: {
     return with_timeout(
         [&](std::uint64_t ut) {
           return umtx_wait(thread, obj, val, ut, true, false);
         },
         false);
   }
-  case 16:
+  case kUmtxOpWakePrivate:
     return umtx_wake_private(thread, obj, val);
-  case 17: {
+  case kUmtxOpMutexWait: {
     return with_timeout([&](std::uint64_t ut) {
       return umtx_wait_umutex(thread, (ptr<umutex>)obj, ut);
     });
   }
-  case 18:
+  case kUmtxOpMutexWake:
     return umtx_wake_umutex(thread, (ptr<umutex>)obj, 0);
-  case 19:
+  case kUmtxOpSemWait:
     return with_timeout(
         [&](std::uint64_t ut) {
           return umtx_sem_wait(thread, (ptr<usem>)obj, ut);
         },
         false);
-  case 20:
+  case kUmtxOpSemWake:
     return umtx_sem_wake(thread, (ptr<usem>)obj);
-  case 21:
+  case kUmtxOpNwakePrivate:
     return umtx_nwake_private(thread, (ptr<void *>)obj, val);
-  case 22:
+  case kUmtxOpMutexWake2:
     return umtx_wake2_umutex(thread, obj, val, uaddr1, uaddr2);
   case 23:
     ORBIS_LOG_ERROR("sys__umtx_op: unknown wake operation", op, val, uaddr1, uaddr2);


### PR DESCRIPTION
Cleanup, doesn't implement any new behaviour.

According to FreeBSD docs, case 23 should be `UMTX_OP_SEM2_WAIT`, but I'm not sure if the same applies to Orbis, so I've left it unimplemented.