### PR TITLE
Update BUILDING.md

### DIFF
--- a/.github/BUILDING.md
+++ b/.github/BUILDING.md
@@ -3,7 +3,7 @@
 
 ### The dependencies for Debian-like distributions.
 ```   
-sudo apt install build-essential cmake libunwind-dev libglfw3-dev libvulkan-dev vulkan-validationlayers-dev libsox-dev git libasound2-dev nasm g++-14
+sudo apt install build-essential cmake libunwind-dev libglfw3-dev libvulkan-dev vulkan-utility-libraries-dev libsox-dev git libasound2-dev nasm g++-14
 ```
 
 ### The dependencies for Fedora distributions:

--- a/.github/BUILDING.md
+++ b/.github/BUILDING.md
@@ -9,7 +9,7 @@ sudo apt install build-essential cmake libunwind-dev libglfw3-dev libvulkan-dev 
 ### The dependencies for Fedora distributions:
 
 ```
-sudo dnf install cmake libunwind-devel glfw-devel vulkan-devel vulkan-validation-layers-devel gcc-c++ gcc sox-devel alsa-lib-devel nasm
+sudo dnf install cmake libunwind-devel glfw-devel vulkan-devel gcc-c++ gcc sox-devel alsa-lib-devel nasm
 ```
 
 ### The dependencies for Arch distributions:

--- a/.github/BUILDING.md
+++ b/.github/BUILDING.md
@@ -3,7 +3,7 @@
 
 ### The dependencies for Debian-like distributions.
 ```   
-sudo apt install build-essential cmake libunwind-dev libglfw3-dev libvulkan-dev vulkan-utility-libraries-dev libsox-dev git libasound2-dev nasm g++-14
+sudo apt install build-essential cmake libunwind-dev libglfw3-dev libvulkan-dev libsox-dev git libasound2-dev nasm g++-14
 ```
 
 ### The dependencies for Fedora distributions:


### PR DESCRIPTION
```
Package vulkan-validationlayers-dev is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  vulkan-utility-libraries-dev
```
on Ubuntu 24 LTS installing ``` vulkan-utility-libraries-dev``` seems to fix the problem