### PR TITLE
libudev-dev is needed on WSL Ubuntu 22.04

### DIFF
--- a/.github/BUILDING.md
+++ b/.github/BUILDING.md
@@ -3,7 +3,7 @@
 
 ### The dependencies for Debian-like distributions.
 ```   
-sudo apt install build-essential cmake libunwind-dev libglfw3-dev libvulkan-dev libsox-dev git libasound2-dev nasm g++-14
+sudo apt install build-essential cmake libunwind-dev libglfw3-dev libvulkan-dev libsox-dev git libasound2-dev nasm libudev-dev g++-14
 ```
 
 ### The dependencies for Fedora distributions:


### PR DESCRIPTION
Added instruction to install the package `libudev-dev`