### PR TITLE
workflows: Remove redundant architecture

### DIFF
--- a/.github/workflows/rpcsx.yml
+++ b/.github/workflows/rpcsx.yml
@@ -48,18 +48,6 @@ jobs:
         include:
           - abi: arm64-v8a
             arch: armv8-a
-          - abi: arm64-v8a
-            arch: armv8.1-a
-          - abi: arm64-v8a
-            arch: armv8.2-a
-          - abi: arm64-v8a
-            arch: armv8.4-a
-          - abi: arm64-v8a
-            arch: armv8.5-a
-          - abi: arm64-v8a
-            arch: armv9-a
-          - abi: arm64-v8a
-            arch: armv9.1-a
           - abi: x86_64
             arch: x86-64
 


### PR DESCRIPTION
- On Android, the arm64-v8a ABI only supports the armv8.0 architecture.

<img width="1067" title="Supported ABIs" height="281" alt="Supported ABIs" src="https://github.com/user-attachments/assets/6d9e3733-a2dc-4b39-9dc4-d951b8a23529" />

See: <https://developer.android.com/ndk/guides/abis>
