### PR TITLE
ipmi: fix hex formatting for SceNpScoreIpc event flag name

### DIFF
--- a/rpcsx/ipmi.cpp
+++ b/rpcsx/ipmi.cpp
@@ -562,9 +562,9 @@ void ipmi::createGnmCompositorObjects(orbis::Process *) {
 void ipmi::createShellCoreObjects(orbis::Process *process) {
   auto fmtHex = [](auto value, bool upperCase = false) {
     if (upperCase) {
-      return std::format("{:X}", value);
+      return std::format("{:08X}", value);
     }
-    return std::format("{:x}", value);
+    return std::format("{:08x}", value);
   };
 
   createIpmiServer(process, "SceSystemLoggerService");


### PR DESCRIPTION
This fixes the name of the SceNpScoreIpc event flag, fixing issues with libSceNpScore's module init failing.

This progresses SWORD ART ONLINE: FATAL BULLET (CUSA10093) slightly further, though the game still crashes before it can show anything.

[Sword Art Online Fatal Bullet logs pre-fix.zip](https://github.com/user-attachments/files/22198603/Sword.Art.Online.Fatal.Bullet.logs.pre-fix.zip)
[Sword Art Online Fatal Bullet logs post-fix.zip](https://github.com/user-attachments/files/22198602/Sword.Art.Online.Fatal.Bullet.logs.post-fix.zip)

This also brings Sword Art Online: Lost Song further, though it seems to be stuck on a loading screen.
<img width="1948" height="1146" alt="image" src="https://github.com/user-attachments/assets/b5e48838-434a-48f1-b34c-dfa5cbe1b029" />
