### PR TITLE
vm: Fix virtual_query error code

### DIFF
--- a/rpcsx/ops.cpp
+++ b/rpcsx/ops.cpp
@@ -279,7 +279,7 @@ orbis::SysResult virtual_query(orbis::Thread *thread,
   }
 
   if (!vm::virtualQuery(addr, flags, (vm::VirtualQueryInfo *)info)) {
-    return ErrorCode::FAULT;
+    return ErrorCode::ACCES;
   }
   return {};
 }


### PR DESCRIPTION
Most errors that can be thrown by `vm::virtualQuery` result in an ACCES error code on real hardware, rather than the FAULT error code currently used here.
Fixing this error return fixes the current hang in Grand Theft Auto V (CUSA00419), now the game plays a little bit of audio then hangs on something else.

Logs:
[Before.zip](https://github.com/user-attachments/files/22348189/Before.zip)
[After.zip](https://github.com/user-attachments/files/22348188/After.zip)
