### PR TITLE
Update hidapi to fix deprecation error and update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ build*/
 .cache/
 rpcs3/git-version.h
 .rx.version
+
+log-*.txt
+tty.txt


### PR DESCRIPTION
With new versions of CMake, configuring would fail, due to the hidapi submodule having a too old CMake version (unless one used -DCMAKE_POLICY_VERSION_MINIMUM=3.5). This issue is already addressed in rpcs3/hidapi, so I only had to update the submodule to fix the problem.
I also added `log-*.txt` and `tty.txt` to .gitignore, so logs created in the project root would get ignored by the version control.