### PR TITLE
Add option to build without (read/write)(fs/gs)base instructions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,6 +141,11 @@ option(WITHOUT_OPENGL "Disable OpenGL" OFF)
 option(WITHOUT_OPENGLEW "Disable OpenGLEW" OFF)
 option(WITHOUT_OPENAL "Disable OpenAL" OFF)
 option(COMPILE_FFMPEG "Compile FFmpeg" ON)
+option(USE_FS_GS_SYSCALL "Use the arch_prctl syscall to interact with fsbase and gsbase instead of x86 instructions. Used for compatibility with some systems, but comes at a performance cost." OFF)
+
+if(USE_FS_GS_SYSCALL)
+    add_definitions(-DUSE_FS_GS_SYSCALL)
+endif()
 
 # rpcs3 options
 option(USE_NATIVE_INSTRUCTIONS "USE_NATIVE_INSTRUCTIONS makes rpcs3 compile with -march=native, which is useful for local builds, but not good for packages." ON)

--- a/rpcsx/thread.cpp
+++ b/rpcsx/thread.cpp
@@ -39,9 +39,16 @@ static auto setContext = [] {
 
 static __attribute__((no_stack_protector)) void
 handleSigSys(int sig, siginfo_t *info, void *ucontext) {
+#ifndef USE_FS_GS_SYSCALL
   if (auto hostFs = _readgsbase_u64()) {
     _writefsbase_u64(hostFs);
   }
+#else
+  uint64_t hostFs = 0;
+  if (syscall(SYS_arch_prctl, ARCH_GET_GS, &hostFs) == 0 && hostFs) {
+    syscall(SYS_arch_prctl, ARCH_SET_FS, hostFs);
+  }
+#endif
 
   // rx::printStackTrace(reinterpret_cast<ucontext_t *>(ucontext),
   // rx::thread::g_current, 1);
@@ -58,7 +65,11 @@ handleSigSys(int sig, siginfo_t *info, void *ucontext) {
 
   thread = orbis::g_currentThread;
   thread->context = prevContext;
+#ifndef USE_FS_GS_SYSCALL
   _writefsbase_u64(thread->fsBase);
+#else
+  syscall(SYS_arch_prctl, ARCH_SET_FS, thread->fsBase);
+#endif
 }
 
 __attribute__((no_stack_protector)) static void
@@ -149,7 +160,11 @@ handleSigUser(int sig, siginfo_t *info, void *ucontext) {
   }
 
   if (inGuestCode) {
+#ifndef USE_FS_GS_SYSCALL
     _writefsbase_u64(thread->fsBase);
+#else
+    syscall(SYS_arch_prctl, ARCH_SET_FS, thread->fsBase);
+#endif
   }
 }
 
@@ -389,6 +404,7 @@ void rx::thread::setupThisThread() {
 void rx::thread::invoke(orbis::Thread *thread) {
   orbis::g_currentThread = thread;
 
+#ifndef USE_FS_GS_SYSCALL
   std::uint64_t hostFs = _readfsbase_u64();
   _writegsbase_u64(hostFs);
 
@@ -397,4 +413,15 @@ void rx::thread::invoke(orbis::Thread *thread) {
 
   ::setContext(context->uc_mcontext);
   _writefsbase_u64(hostFs);
+#else
+  std::uint64_t hostFs;
+  syscall(SYS_arch_prctl, ARCH_GET_FS, &hostFs);
+  syscall(SYS_arch_prctl, ARCH_SET_GS, hostFs);
+
+  syscall(SYS_arch_prctl, ARCH_SET_FS, thread->fsBase);
+  auto context = reinterpret_cast<ucontext_t *>(thread->context);
+
+  ::setContext(context->uc_mcontext);
+  syscall(SYS_arch_prctl, ARCH_SET_FS, hostFs);
+#endif
 }


### PR DESCRIPTION
Since these instructions don't appear to exist on the PS4, an optional replacement is provided by this PR in the form of the new `USE_FS_GS_SYSCALL` CMake option, making the emulator boot on PS4 Linux with one less workaround.