### PR TITLE
build: add missing includes for GCC 16 compatibility

### DIFF
--- a/rpcsx/AudioOut.cpp
+++ b/rpcsx/AudioOut.cpp
@@ -12,6 +12,7 @@
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <thread>
+#include <unistd.h>
 #include <vector>
 
 AudioOut::AudioOut() {

--- a/rpcsx/gpu/Device.cpp
+++ b/rpcsx/gpu/Device.cpp
@@ -24,6 +24,7 @@
 #include <stop_token>
 #include <sys/mman.h>
 #include <thread>
+#include <unistd.h>
 
 #define GLFW_INCLUDE_NONE
 #include <GLFW/glfw3.h>

--- a/rpcsx/vfs.cpp
+++ b/rpcsx/vfs.cpp
@@ -6,6 +6,7 @@
 #include "orbis/error/SysResult.hpp"
 #include <filesystem>
 #include <map>
+#include <mutex>
 #include <string_view>
 
 static orbis::ErrorCode devfs_stat(orbis::File *file, orbis::Stat *sb,

--- a/rx/include/rx/SharedCV.hpp
+++ b/rx/include/rx/SharedCV.hpp
@@ -3,6 +3,7 @@
 #include "SharedAtomic.hpp"
 #include "SharedMutex.hpp"
 #include <chrono>
+#include <climits>
 #include <cstdint>
 #include <mutex>
 #include <system_error>

--- a/tools/spv-gen/spv-gen.cpp
+++ b/tools/spv-gen/spv-gen.cpp
@@ -5,6 +5,7 @@
 #include <nlohmann/json.hpp>
 #include <set>
 #include <string>
+#include <unistd.h>
 #include <unordered_set>
 #include <vector>
 


### PR DESCRIPTION
## Summary

Newer libstdc++ (as shipped with GCC 16) no longer transitively includes several headers that the codebase relies on, causing build failures. This adds explicit includes where the symbols are actually used:

- `<unistd.h>` for `::dup2`/`::close` in `spv-gen.cpp`, `Device.cpp`, `AudioOut.cpp`
- `<climits>` for `INT_MAX` in `SharedCV.hpp`
- `<mutex>` for `std::lock_guard` in `vfs.cpp`

## Notes

These are purely additive include fixes — no behavioral changes. This fixes compile errors in newer libstdc++ versions that have tightened their transitive include graph.
